### PR TITLE
fix: honor prefers-reduced-motion (#3)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1068,6 +1068,17 @@
             background: var(--field-gold); color: #000;
         }
         .quit-btn__icon { font-size: 1rem; line-height: 1; margin-top: 1px; }
+
+        @media (prefers-reduced-motion: reduce) {
+            *, *::before, *::after {
+                animation-duration: 0.001s !important;
+                animation-iteration-count: 1 !important;
+                transition-duration: 0.001s !important;
+                scroll-behavior: auto !important;
+            }
+            #starfield { display: none; }
+            .project-card { opacity: 1 !important; transform: none !important; }
+        }
     </style>
 </head>
 <body>
@@ -1427,6 +1438,7 @@
     // STARFIELD — Dense animated twinkling stars
     // ==========================================
     (function createStarfield() {
+        if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
         const container = document.getElementById('starfield');
         const count = 150;
         const colorClasses = ['', 'star--warm', 'star--cool'];


### PR DESCRIPTION
## Summary
- Adds `@media (prefers-reduced-motion: reduce)` block to neutralize infinite twinkle/drift/compass-spin animations and scroll-reveal transitions.
- Bails out of the 150-node starfield DOM generation when reduced motion is set, saving work on low-power devices.
- Addresses WCAG 2.1 SC 2.2.2 (Pause, Stop, Hide).

fixes #3

## Test plan
- [ ] Enable macOS System Settings → Accessibility → Display → "Reduce motion", reload — confirm starfield hidden, compass not spinning, project cards visible without fade.
- [ ] Disable reduce-motion, reload — confirm animations return to normal.
- [ ] DevTools: `window.matchMedia('(prefers-reduced-motion: reduce)').matches` reports the expected boolean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)