### PR TITLE
Sandbox game iframes + postMessage localStorage proxy (fixes #2)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1402,7 +1402,7 @@
                 <span class="quit-btn__icon">✕</span>
             </button>
         </div>
-        <iframe id="game-iframe" src="about:blank" sandbox="allow-scripts allow-same-origin" allowfullscreen></iframe>
+        <iframe id="game-iframe" src="about:blank" sandbox="allow-scripts" allowfullscreen></iframe>
     </div>
 
 </div>
@@ -1624,6 +1624,130 @@
             gameIframe.src = 'about:blank';
             globalControls.style.display = 'flex';
             setMode('launcher');
+        });
+    })();
+
+    // ==========================================
+    // LOCALSTORAGE PROXY — postMessage bridge for sandboxed game iframes
+    // ==========================================
+    // Game iframes are sandboxed without `allow-same-origin`, so they run
+    // in an opaque origin and cannot touch their own localStorage. This
+    // proxy lets them persist state through the launcher.
+    //
+    // Protocol — request (iframe -> launcher):
+    //   { type: 'ls-proxy-request', requestId: string,
+    //     op: 'getItem'|'setItem'|'removeItem'|'clear'|'key'|'length',
+    //     key?: string, value?: string, index?: number }
+    //
+    // Response (launcher -> iframe):
+    //   { type: 'ls-proxy-response', requestId: string, ok: boolean,
+    //     value?: string|null, error?: string }
+    //
+    // Storage is namespaced by the first path segment of the iframe src
+    // (e.g. "pi-game", "cozy-solitaire") so games cannot read each
+    // other's data or the launcher's own keys. Stored key shape:
+    //   __game_proxy__/<namespace>/<key>
+    (function gameStorageProxy() {
+        const gameIframe = document.getElementById('game-iframe');
+        if (!gameIframe) return;
+
+        const KEY_PREFIX = '__game_proxy__/';
+
+        function namespaceFor(src) {
+            try {
+                const u = new URL(src, window.location.href);
+                if (u.protocol !== 'http:' && u.protocol !== 'https:') return null;
+                const seg = u.pathname.replace(/^\/+|\/+$/g, '').split('/')[0];
+                return seg || null;
+            } catch {
+                return null;
+            }
+        }
+
+        function fullKey(ns, key) { return KEY_PREFIX + ns + '/' + key; }
+
+        function nsKeys(ns) {
+            const prefix = KEY_PREFIX + ns + '/';
+            const out = [];
+            for (let i = 0; i < localStorage.length; i++) {
+                const k = localStorage.key(i);
+                if (k && k.startsWith(prefix)) out.push(k);
+            }
+            return out;
+        }
+
+        function handle(op, data, ns) {
+            switch (op) {
+                case 'getItem':
+                    if (typeof data.key !== 'string') throw new Error('key required');
+                    return { value: localStorage.getItem(fullKey(ns, data.key)) };
+                case 'setItem':
+                    if (typeof data.key !== 'string' || typeof data.value !== 'string') {
+                        throw new Error('key and value required');
+                    }
+                    localStorage.setItem(fullKey(ns, data.key), data.value);
+                    return {};
+                case 'removeItem':
+                    if (typeof data.key !== 'string') throw new Error('key required');
+                    localStorage.removeItem(fullKey(ns, data.key));
+                    return {};
+                case 'clear':
+                    nsKeys(ns).forEach(k => localStorage.removeItem(k));
+                    return {};
+                case 'key': {
+                    if (typeof data.index !== 'number') throw new Error('index required');
+                    const stripped = nsKeys(ns).map(k => k.slice((KEY_PREFIX + ns + '/').length));
+                    return { value: stripped[data.index] !== undefined ? stripped[data.index] : null };
+                }
+                case 'length':
+                    return { value: nsKeys(ns).length };
+                case 'dump': {
+                    const prefix = KEY_PREFIX + ns + '/';
+                    const out = {};
+                    for (let i = 0; i < localStorage.length; i++) {
+                        const k = localStorage.key(i);
+                        if (k && k.startsWith(prefix)) out[k.slice(prefix.length)] = localStorage.getItem(k);
+                    }
+                    return { data: out };
+                }
+                default:
+                    throw new Error('unsupported op: ' + op);
+            }
+        }
+
+        window.addEventListener('message', (event) => {
+            if (event.source !== gameIframe.contentWindow) return;
+            if (event.origin !== 'null') return;
+            const data = event.data;
+            if (!data || data.type !== 'ls-proxy-request') return;
+            if (typeof data.requestId !== 'string') return;
+
+            const ns = namespaceFor(gameIframe.getAttribute('src') || '');
+            if (!ns) {
+                event.source.postMessage({
+                    type: 'ls-proxy-response',
+                    requestId: data.requestId,
+                    ok: false,
+                    error: 'no active game'
+                }, '*');
+                return;
+            }
+
+            try {
+                const result = handle(data.op, data, ns);
+                event.source.postMessage(Object.assign({
+                    type: 'ls-proxy-response',
+                    requestId: data.requestId,
+                    ok: true
+                }, result), '*');
+            } catch (err) {
+                event.source.postMessage({
+                    type: 'ls-proxy-response',
+                    requestId: data.requestId,
+                    ok: false,
+                    error: String(err && err.message || err)
+                }, '*');
+            }
         });
     })();
 


### PR DESCRIPTION
## Summary

- Drop `allow-same-origin` from the game iframe sandbox so games run in an opaque origin. The previous `sandbox=\"allow-scripts allow-same-origin\"` combination was effectively unsandboxed per [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#sandbox), since the iframe and its parent share `paulgibeault.github.io`.
- Add a postMessage bridge in the launcher that proxies `localStorage` operations on behalf of the active sandboxed iframe, so games can keep persisting save state, high scores, and settings.
- Storage is namespaced per game (first path segment of the iframe `src`, e.g. `pi-game`), so games cannot read each other's data or the launcher's own keys (`fontScale`, `appMode`).

## Why

Closes #2. With `allow-same-origin` set, a compromised third-party CDN script in any one game could pivot through `window.parent` to read/write the launcher's `localStorage`, unregister its service worker, modify portfolio DOM, or remove its own sandbox attribute. The new sandbox runs each game in an opaque origin that has no DOM/storage/SW access to the parent — only `postMessage`.

## Protocol

Request (iframe → launcher):

```
{ type: 'ls-proxy-request', requestId: string,
  op: 'getItem'|'setItem'|'removeItem'|'clear'|'key'|'length',
  key?: string, value?: string, index?: number }
```

Response (launcher → iframe):

```
{ type: 'ls-proxy-response', requestId: string, ok: boolean,
  value?: string|null, error?: string }
```

Stored key shape in the launcher's localStorage: `__game_proxy__/<namespace>/<key>`.

The handler accepts a message only when:
- `event.source === gameIframe.contentWindow` (only the active game)
- `event.origin === 'null'` (sandboxed opaque origin)
- `data.type === 'ls-proxy-request'` and `data.requestId` is a string
- iframe `src` resolves to an http(s) URL (rejects `about:blank` after quit)

## Required follow-up — game repos

Until each game adds a client-side shim, its persisted state will not work when launched from the launcher (games opened standalone via the \"Play\" button continue to work, since they have their own origin context).

Each of the following needs a small bootstrap script that detects sandboxed mode and overrides `window.localStorage` with a Proxy that uses the protocol above:

- [ ] `paulgibeault/pi-game`
- [ ] `paulgibeault/si-syn`
- [ ] `paulgibeault/hecknsic`
- [ ] `paulgibeault/cozy-solitaire`

## Test plan

- [ ] Serve repo locally (`python3 -m http.server`), open launcher, click each game tile.
- [ ] In game iframe DevTools console, confirm `localStorage.getItem('x')` throws `SecurityError` (proves opaque origin).
- [ ] From iframe console, send a `ls-proxy-request` with `op: 'setItem'` and confirm `__game_proxy__/<game>/<key>` appears in the launcher's localStorage.
- [ ] Confirm a request from a non-active iframe or with a missing `requestId` is silently ignored.
- [ ] Confirm a stale request after quitting (iframe `src` is `about:blank`) returns `ok: false, error: 'no active game'`.
- [ ] Verify launcher's own keys (`fontScale`, `appMode`) cannot be touched by a `setItem` from any game.

🤖 Generated with [Claude Code](https://claude.com/claude-code)