### PR TITLE
Arcade platform: security fixes + fleet-wide SDK/launcher enhancements (#17)

### DIFF
--- a/ARCADE_PLATFORM.md
+++ b/ARCADE_PLATFORM.md
@@ -28,24 +28,36 @@ await Arcade.ready;                    // resolves on welcome (or immediately st
 // STORAGE — sync, identical standalone or framed
 Arcade.state.get(key)                 // localStorage 'arcade.v1.<gameId>.<key>'
 Arcade.state.set(key, value)
+Arcade.state.set(key, value, { exportable: false })  // local-only: excluded from save files
 Arcade.state.remove(key)
 Arcade.state.getOrInit(key, defaults) // deep-merges defaults under any stored value
 Arcade.state.onChange(key, fn)
 Arcade.state.migrate(version, fn)     // runs fn exactly once per (gameId, version)
+Arcade.state.adopt(legacyKey, newKey?, { json? })  // read → namespaced write → delete original
 Arcade.global.get(key)                // localStorage 'arcade.v1.global.<key>'
 Arcade.global.set(key, value)
 Arcade.onStateReplaced(fn)            // fires after a launcher import — re-read state
 
 // PLAYER, SCORES, STATS — shared identity + leaderboard/stat helpers
 Arcade.player.name() / setName(s)     // sticky display name, arcade.v1.global.playerName
-Arcade.scores.add(category, entry)    // top-100 sorted list, stamps name + ts
-Arcade.scores.list(category, opts) / best(category) / clear(category)
+Arcade.scores.add(category, entry, opts)  // top-100 sorted list, stamps name + ts;
+                                      // opts.order 'desc' (default) | 'asc' (times);
+                                      // entry.key labels an entry for keyed bests
+Arcade.scores.list(category, opts) / best(category) / best(category, key) / clear(category)
 Arcade.stats.get(category) / getOrInit(category, defaults) / update(category, fn)
 
-// LIFECYCLE — pause cleanly when the launcher hides/evicts this iframe
-Arcade.onSuspend(fn)                  // iframe hidden or about to be evicted
-Arcade.onResume(fn)                   // iframe shown again
+// LIFECYCLE — launcher iframe-pool hints when framed, page visibility
+// standalone; both sources merge into one deduplicated stream
+Arcade.onSuspend(fn)                  // iframe hidden / about to be evicted / page hidden
+Arcade.onResume(fn)                   // shown again
+Arcade.context.suspended              // current effective state (also mirrored as
+                                      // <html data-arcade-suspended="true|false">)
 Arcade.session.start(opts)            // wall-clock tracker wired to suspend/resume
+Arcade.session.setTimeout(fn, ms)     // freeze while suspended; cancel on stateReplaced
+Arcade.session.setInterval(fn, ms)    // both return { cancel() }
+Arcade.loop(fn)                       // managed rAF loop: { start, stop, kick, running,
+                                      // dispose } — auto-cancels on suspend, resumes only
+                                      // if it was running, deltas exclude suspended time
 
 // MULTIPLAYER — async, gracefully no-ops when standalone
 Arcade.peer.status()                  // 'unavailable' | 'idle' | 'connecting' | 'connected' | 'interrupted'
@@ -53,7 +65,12 @@ Arcade.peer.status()                  // 'unavailable' | 'idle' | 'connecting' |
                                       // sends queue + replay; don't reset game state
 Arcade.peer.onStatus(fn)
 Arcade.peer.send(payload)
-Arcade.peer.onMessage(fn)
+Arcade.peer.onMessage(fn)             // fn(payload, fromPeer) — fromPeer is the sending
+                                      // device's stable deviceId once identity completes
+Arcade.peer.self() / remote()         // stable device identities ({ deviceId, name } | null)
+Arcade.peer.onReady(fn)               // remote device has THIS game mounted and listening
+Arcade.peer.sendBlob(blob, { onProgress }) / onBlob(fn)  // chunked large payloads
+Arcade.peer.queue() / onQueue(fn)     // replay-queue { depth, limit, overflowed }
 
 // SETTINGS — launcher pushes its current values, SDK auto-applies CSS vars/attrs
 Arcade.settings.fontScale()           // current launcher font scale (1 = default)
@@ -96,6 +113,7 @@ All messages namespaced `arcade:` to avoid collision.
 ```
 child → parent:  { type: 'arcade:hello',   gameId, version: 2 }
 parent → child:  { type: 'arcade:welcome', version: 2, peerStatus: 'idle',
+                   peers: [{ deviceId, name }, ...],   // live remote devices (roster seed)
                    settings: { fontScale, theme, reducedMotion, audioVolume, handedness } }
 ```
 
@@ -105,8 +123,11 @@ If no `welcome` arrives within ~300ms, SDK locks into standalone mode.
 
 ```
 child  → parent: { type: 'arcade:peer.send',         payload }
-parent → child:  { type: 'arcade:peer.message',      payload, fromPeer }
+parent → child:  { type: 'arcade:peer.message',      payload, fromPeer }   // fromPeer = sender deviceId
 parent → child:  { type: 'arcade:peer.status',       status }
+parent → child:  { type: 'arcade:peer.identity',     deviceId, name }      // roster update
+parent → child:  { type: 'arcade:peer.ready',        deviceId, name }      // remote same-game listening
+parent → child:  { type: 'arcade:peer.queue',        depth, limit, overflowed } // replay-queue visibility
 parent → child:  { type: 'arcade:state.replaced' }               // after file import
 parent → child:  { type: 'arcade:settings.changed',  settings }  // launcher setting updated
 parent → child:  { type: 'arcade:lifecycle.suspend' }             // iframe hidden, or about to be evicted
@@ -114,7 +135,7 @@ parent → child:  { type: 'arcade:lifecycle.resume' }              // iframe sh
 child  → parent: { type: 'arcade:ui.toast',          message, kind, duration }
 ```
 
-Ten message types total (see GAME_INTEGRATION.md §14 for the full summary table). The launcher routes peer messages by `gameId` so multiple games could in principle multiplex one connection, though the current design assumes one foreground game at a time.
+Thirteen message types total (see GAME_INTEGRATION.md §14 for the full summary table). The launcher routes peer messages by `gameId` so multiple games could in principle multiplex one connection, though the current design assumes one foreground game at a time. Between launchers, presence frames (`{arcade:1, kind:'presence'|'presence-ack', gameId}`) announce that a game is mounted and listening; the receiving launcher surfaces them to the matching game as `arcade:peer.ready`.
 
 **Legacy compatibility shim:** a small number of older games (e.g. hecknsic) shipped their own postMessage-backed `localStorage` override before the SDK existed. The launcher still answers that game's `'ls-proxy-request'`/`'ls-proxy-response'` protocol (namespaced into `arcade.v1.<gameId>.ls.<key>`) purely so those games don't hang — this is launcher-side legacy support, not part of the `arcade:` protocol, and new games should use `Arcade.state.*` directly rather than rolling a shim of their own.
 
@@ -191,7 +212,7 @@ WebRTC can't skip the offer/answer ceremony — DTLS fingerprints must flow both
 The full protocol spec lives in `QRCodeP2P/PROTOCOL.md` (§7). Launcher wiring:
 
 - **Opt-in per pair, both sides:** at first contact (after the naming prompt) the launcher asks whether to reconnect automatically; the flag lives in `knownPeers[deviceId].autoReconnect` and is toggleable per peer in the Known Peers panel (🔁/🚫). When both sides opt in, a pairing secret is derived over the live DTLS channel — and **re-derived on every later manual ceremony** (each physical meeting is a fresh trust event).
-- **What it does:** if the connection dies completely (grace expired, channel closed, both networks changed, browsers restarted), the transport re-signals through a public MQTT-over-WSS broker (`wss://test.mosquitto.org:8081/mqtt`). Everything published is end-to-end AEAD-sealed with per-pair keys; topics are unlinkable daily HMACs; epochs kill replays; keys ratchet on every successful reconnect. The broker can only delay or drop — worst case is falling back to the one-tap manual re-pair.
+- **What it does:** if the connection dies completely (grace expired, channel closed, both networks changed, browsers restarted), the transport re-signals through a public MQTT-over-WSS broker (`wss://test.mosquitto.org:8081/mqtt`). Everything published is end-to-end AEAD-sealed with per-pair keys; topics are unlinkable daily HMACs; epochs kill replays; keys ratchet on every successful reconnect. **Content** is therefore safe from the broker: it can only delay or drop, and the worst case is falling back to the one-tap manual re-pair. **Metadata** is not: the broker — and anyone subscribed to the public relay's topic space — learns both devices' IP addresses, the fact that some pair is rendezvousing, and when. If that linkage matters to you, don't opt in to auto-reconnect; manual QR/link pairing never touches a relay.
 - **What games see:** `interrupted` for the whole repair (the launcher holds the `idle` transition for a beat so a terminal teardown claimed by rendezvous never flashes `idle`), then `connected` with the SAME session — sends made while the link was dead queue into the stashed session and replay on adoption, exactly-once.
 - **Resume-on-launch:** `arcade.v1._meta.lastLiveSession` timestamps live paired sessions; if the launcher opens within 6 h of one, it boots the transport and calls `resumeRendezvous()` — two devices whose browsers were both killed re-establish the session with zero interaction.
 - **Presence discipline:** relays are contacted only during active repair episodes (10-min cap, backoff) and the resume check — no standing "I'm online" beacon, ever.

--- a/GAME_INTEGRATION.md
+++ b/GAME_INTEGRATION.md
@@ -76,12 +76,47 @@ silently dropped on import, so old keys won't survive a cross-device save.
   Arcade.onStateReplaced(() => { /* re-hydrate UI from Arcade.state.get(...) */ });
   ```
 
+  Treat `onStateReplaced` like a fresh boot: recompute your start screen /
+  current level / unlocks from storage. Do **not** assume the screen the user
+  is on is still valid in the imported save — e.g. an imported file may not
+  have the level the player was just on unlocked at all.
+
+- [ ] Bulky local-only data (telemetry, replay buffers, caches) should not
+  inflate every save file: write it with
+  `Arcade.state.set('telemetry', data, { exportable: false })`. The flag is
+  sticky per key until you set `{ exportable: true }`.
+
 ### One-shot migration of legacy keys
 
 `Arcade.state.migrate(version, fn)` runs `fn` exactly once per `(gameId, version)`
 — the SDK records a sentinel at `arcade.v1.<gameId>._migrated.<version>` so
-subsequent loads skip. Use it to copy legacy keys into the namespaced layout
-and delete the originals:
+subsequent loads skip.
+
+For the common "move one legacy key into the namespace" case,
+`Arcade.state.adopt(legacyKey, newKey?)` is a one-liner: it reads the legacy
+key, writes it under `arcade.v1.<gameId>.<newKey>` (JSON-parsing the old raw
+string unless you pass `{ json: false }`), and deletes the original — without
+clobbering an already-namespaced value:
+
+```js
+Arcade.state.migrate('v1', () => {
+    Arcade.state.adopt('hecknsic_settings', 'settings');
+    Arcade.state.adopt('hecknsic_save', 'savedGame');
+});
+```
+
+Version bumps *within* the namespace need no new machinery — use a fresh
+migrate sentinel and rewrite in place:
+
+```js
+Arcade.state.migrate('v2-board-shape', () => {
+    const s = Arcade.state.get('savedGame');
+    if (s && !Array.isArray(s.board)) Arcade.state.set('savedGame', upgradeBoard(s));
+});
+```
+
+For anything more involved (renamed score categories, per-mode splits), use
+the full form:
 
 ```js
 Arcade.state.migrate('v1', () => {
@@ -117,7 +152,8 @@ Arcade.state.migrate('v1', () => {
 ## 4. Player profile, scores, and stats
 
 - [ ] Use `Arcade.player.name()` / `Arcade.player.setName(s)` for the sticky display name. It lives at `arcade.v1.global.playerName` so every game shares it.
-- [ ] If your game has a leaderboard, use `Arcade.scores.add(category, { score, name?, meta? })` and `Arcade.scores.list(category, { limit })`. The SDK keeps the top 100 sorted descending and stamps `name` (from `Arcade.player.name()`) and `ts` automatically.
+- [ ] If your game has a leaderboard, use `Arcade.scores.add(category, { score, name?, key?, meta? }, opts?)` and `Arcade.scores.list(category, { limit })`. The SDK keeps the top 100 sorted and stamps `name` (from `Arcade.player.name()`) and `ts` automatically. Higher-is-better is the default; time/move-count games pass `{ order: 'asc' }` on every add so lower scores rank first.
+- [ ] For best-per-thing records (best time per board code, best score per level), stamp each entry with `key` and read back with `Arcade.scores.best(category, key)`. If you need a full keyed map rather than a ranked list, `Arcade.stats` is the blessed home — `Arcade.stats.update(category, prev => ({ ...prev, [boardCode]: bestMs }))`.
 - [ ] If your game tracks counters (games played / won / streak / best time), use `Arcade.stats.update(category, prev => next)` for atomic-style updates and `Arcade.stats.get(category)` to read. When adding a new field to an existing stats category, use `Arcade.stats.getOrInit(category, DEFAULTS)` instead of `get` — it deep-merges defaults under the stored value so saves from older versions pick up newly-added fields without a migration.
 
 ---
@@ -131,9 +167,19 @@ every change. The SDK applies the visual ones to the game's `<html>` for free:
 | ---------------- | ----------------------------------- | -------------------------------------------------- |
 | `fontScale`      | `Arcade.settings.fontScale()`       | `style="--font-scale: <n>"`                        |
 | `theme`          | `Arcade.settings.theme()`           | `data-theme="light"` or `data-theme="dark"`        |
-| `reducedMotion`  | `Arcade.settings.reducedMotion()`   | `style="--motion-scale: 0"` (1 otherwise)          |
+| `reducedMotion`  | `Arcade.settings.reducedMotion()`   | `data-reduced-motion="true|false"` + `style="--motion-scale: 0"` (1 otherwise) |
 | `audioVolume`    | `Arcade.settings.audioVolume()`     | `style="--audio-volume: <0..1>"` (read in JS)      |
 | `handedness`     | `Arcade.settings.handedness()`      | `data-handedness="left"` or `data-handedness="right"` |
+
+**Reduced motion is handled for you by default:** the SDK's injected base
+style includes a kill-switch rule — when `data-reduced-motion="true"`, every
+CSS animation and transition collapses to a single instant frame
+(`animation-duration: .001ms !important`, etc.). No `calc(var(--motion-scale))`
+rewrites needed for the common case. A game that wants to manage motion
+itself (e.g. keep some animations, slow others) opts out of the kill rule by
+setting `data-arcade-keep-motion` on `<html>` and keying its own CSS/JS off
+`[data-reduced-motion="true"]` or `--motion-scale`. Canvas/JS-driven motion
+still needs the JS checks below either way.
 
 To benefit:
 
@@ -186,13 +232,31 @@ out of the cache sooner. The SDK delivers explicit hints:
 
 - [ ] Subscribe to `Arcade.onSuspend(fn)` to pause your game loop / mute audio.
 - [ ] Subscribe to `Arcade.onResume(fn)` to unpause and reset any `lastTime` accumulators.
-- [ ] You no longer need a separate `visibilitychange` handler — the SDK fires `onSuspend` whenever the launcher hides the iframe (which encompasses both quitting to launcher and tab/window hide).
+- [ ] You no longer need a separate `visibilitychange` handler — the SDK merges the launcher's iframe-pool hints with the page's own visibility (`visibilitychange`/`pagehide`) into one deduplicated suspend/resume stream. That includes **standalone**: a game opened at its GitHub Pages URL gets the same `onSuspend` when its tab hides, so flush/pause logic in `onSuspend` works identically in both modes (and `Arcade.session.start({ persistKey })` persists standalone too).
+- [ ] Code that mounts mid-session (or CSS) can read the current state at any time: `Arcade.context.suspended`, or the `data-arcade-suspended="true|false"` attribute the SDK maintains on `<html>`. A hidden iframe's own `document.visibilityState` stays `"visible"`, so poll-style time trackers must check `Arcade.context.suspended`, not visibility.
 
 ```js
 let paused = false;
 Arcade.onSuspend(() => { paused = true; audio.suspend(); });
 Arcade.onResume(() => { paused = false; lastFrame = performance.now(); audio.resume(); });
 ```
+
+For a canvas render loop, skip the hand-rolled rAF bookkeeping entirely —
+`Arcade.loop(fn)` cancels on suspend, re-requests on resume **only if it was
+running**, and never lets suspended time leak into a delta (the first frame
+after resume gets `delta = 0`):
+
+```js
+const loop = Arcade.loop((deltaMs) => { update(deltaMs); draw(); });
+loop.start();            // begin
+loop.stop();             // in-game pause menu
+loop.kick();             // one frame on demand (dirty-flag renderers)
+```
+
+For timers, `Arcade.session.setTimeout(fn, ms)` / `Arcade.session.setInterval(fn, ms)`
+freeze while suspended (remaining time is preserved and re-armed on resume)
+and cancel themselves when a save import replaces state. Both return
+`{ cancel() }`.
 
 For wall-time tracking (best-time stats, an elapsed-time UI), use
 `Arcade.session.start()` instead of hand-rolling `performance.now()` math —
@@ -288,7 +352,17 @@ links, no signaling server. Games never touch any of that; the whole surface is:
 Arcade.peer.status();              // 'unavailable' | 'idle' | 'connecting' | 'connected' | 'interrupted'
 Arcade.peer.onStatus(s => ...);    // gate multiplayer UI on this
 Arcade.peer.send({ move: 'e4' });  // JSON-safe payload; false unless connected/interrupted
-Arcade.peer.onMessage(payload => ...);  // exactly what the other game sent
+Arcade.peer.onMessage((payload, fromPeer) => ...);  // fromPeer = sender's stable deviceId
+
+Arcade.peer.self();                // { deviceId, name } for THIS device (null before first pairing)
+Arcade.peer.remote();              // most recently seen remote device, or null
+Arcade.peer.onReady(({ deviceId }) => ...);  // remote has THIS game mounted & listening
+
+Arcade.peer.sendBlob(file, { onProgress });  // chunked large payloads; Promise
+Arcade.peer.onBlob((blob, { name, size, fromPeer }) => ...);
+
+Arcade.peer.queue();               // { depth, limit, overflowed } — replay-queue visibility
+Arcade.peer.onQueue(q => ...);     // pushed while 'interrupted'; overflowed ⇒ resync after recovery
 ```
 
 Rules of the road:
@@ -301,8 +375,12 @@ Rules of the road:
       big (the channel is ordered + reliable).
 - [ ] Both devices run the same game for a session. Messages are routed by
       `gameId` — a message sent while the other device has a different game
-      mounted is dropped silently. Design for "my peer might not be listening
-      yet": announce with a hello payload and wait for the echo.
+      mounted is dropped silently. You no longer need a hand-rolled
+      hello/echo handshake for "is my peer listening yet?": subscribe to
+      `Arcade.peer.onReady(...)` — the launchers exchange presence
+      announcements whenever a game mounts (and on every reconnect), so it
+      fires as soon as the same game is listening on both ends. It may fire
+      more than once per session; treat it as an idempotent signal.
 - [ ] `'connected'` means the data channel is genuinely open (transport
       v1.5.1 semantics) — safe to send immediately on the transition.
 - [ ] **Ride out `'interrupted'`** (transport v1.7): the peer's device blipped
@@ -318,7 +396,16 @@ Rules of the road:
       while the rendezvous layer repairs it — same rule: wait, don't reset.
 - [ ] High-rate realtime games (30+ msgs/sec) should pause their send loop
       while `'interrupted'` and resync authoritative state on `'connected'` —
-      the replay queue is capped at 1000 messages.
+      the replay queue is capped at 1000 messages. The cap is visible:
+      `Arcade.peer.queue()` returns `{ depth, limit, overflowed }` (pushed to
+      `onQueue` subscribers during an episode), and `overflowed === true`
+      means the oldest unacknowledged messages were already dropped, so
+      resync rather than trusting replay.
+- [ ] Files and other large payloads: don't hand-roll base64 chunking —
+      `Arcade.peer.sendBlob(blob, { onProgress })` chunks over the ordered
+      channel and the receiver's `Arcade.peer.onBlob` fires with a
+      reassembled `Blob`. Mind the replay cap when sending large files while
+      `'interrupted'`.
 - [ ] Don't cache `status()` at init: a game mounted mid-session receives
       `'connected'` in its welcome, and live transitions arrive via `onStatus`.
 
@@ -358,11 +445,37 @@ anchor-triggered downloads from a sandboxed iframe.
 Several games already ship a `manifest.json` and `sw.js`. Because every game
 and the launcher live on the same origin, sloppy scopes will collide.
 
+Start from the reference worker at
+[`tools/templates/game-sw.js`](tools/templates/game-sw.js) — it encodes every
+rule below (scope-filtered fetch handler, version-keyed cache, own-caches-only
+cleanup).
+
 - [ ] `manifest.json` `"scope"` and `"start_url"` are scoped to `/<gameId>/`, not `/`.
 - [ ] If the game registers a service worker, register it with `{ scope: '/<gameId>/' }` and place `sw.js` inside that path.
-- [ ] The service worker only caches assets under `/<gameId>/`. **Never** cache `/arcade-sdk.js` or anything at the launcher root — the SDK will `console.warn` if it detects this at load.
+- [ ] The service worker only caches assets under `/<gameId>/`. **Never** cache `/arcade-sdk.js` or anything at the launcher root — the SDK inspects the origin's caches at load and reports a `console.error` (plus a visible toast in `?dev=1` mode) when a game cache holds launcher files.
+- [ ] The fetch handler must ignore out-of-scope URLs. A controlled page routes **every** request through its SW — including `/arcade-sdk.js` — so the guard is mandatory, not optional:
 
-> The launcher's own service worker lives at `/sw.js` (root scope) and intentionally caches only launcher-owned files (`index.html`, `arcade-sdk.js`, `styles.css`, launcher images). It does not intercept game URLs. The launcher SW is also skipped on loopback hosts (`localhost`, `127.x`, `::1`) so local-dev edits to launcher or SDK are never masked by stale cache.
+  ```js
+  self.addEventListener('fetch', (event) => {
+    const url = new URL(event.request.url);
+    if (url.origin !== self.location.origin) return;
+    if (!url.pathname.startsWith('/<gameId>/')) return;  // ← the load-bearing line
+    event.respondWith(
+      caches.match(event.request).then((hit) => hit || fetch(event.request))
+    );
+  });
+  ```
+
+- [ ] **Never clean up origin-wide.** `caches.keys()` and
+  `navigator.serviceWorker.getRegistrations()` see every game's caches and
+  workers *plus the launcher's* — one game shipping
+  `caches.keys().then(names => names.map(n => caches.delete(n)))` or a blanket
+  `getRegistrations().then(rs => rs.forEach(r => r.unregister()))` wipes the
+  whole arcade's offline support. Filter cache deletions to your own
+  version-keyed prefix (`<gameId>-*`) and never unregister workers you didn't
+  register.
+
+> The launcher's own service worker lives at `/sw.js` (root scope), caches only launcher-owned files (`index.html`, `arcade-sdk.js`, `styles.css`, `p2p/`, launcher images), and its fetch handler path-filters to those same trees — requests for `/<gameId>/...` fall through untouched. The launcher SW is also skipped on loopback hosts (`localhost`, `127.x`, `::1`) so local-dev edits to launcher or SDK are never masked by stale cache.
 
 ---
 
@@ -473,13 +586,16 @@ acts on messages from iframes it mounted via the pool.
 
 ```
 child  → parent: arcade:hello              { gameId, version }
-parent → child:  arcade:welcome            { version, peerStatus, settings }
+parent → child:  arcade:welcome            { version, peerStatus, peers, settings }
 parent → child:  arcade:settings.changed   { settings }
 parent → child:  arcade:state.replaced     { }                      // after file import
 parent → child:  arcade:lifecycle.suspend  { }                      // iframe hidden, or about to be evicted
 parent → child:  arcade:lifecycle.resume   { }                      // iframe shown
 parent → child:  arcade:peer.status        { status }
-parent → child:  arcade:peer.message       { payload, fromPeer }
+parent → child:  arcade:peer.message       { payload, fromPeer }    // fromPeer = sender deviceId
+parent → child:  arcade:peer.identity      { deviceId, name }       // roster update
+parent → child:  arcade:peer.ready         { deviceId, name }       // remote same-game listening
+parent → child:  arcade:peer.queue         { depth, limit, overflowed }
 child  → parent: arcade:peer.send          { payload }
 child  → parent: arcade:ui.toast           { message, kind, duration }
 ```

--- a/arcade-known-peers.js
+++ b/arcade-known-peers.js
@@ -1,0 +1,61 @@
+/* arcade-known-peers.js — the single owner of arcade.v1._meta.knownPeers.
+ *
+ * Both writers import this module: the launcher menu's Known Peers panel
+ * (rename / delete, loaded at startup — it's tiny) and the lazily-imported
+ * P2P bridge (upsert on every identity handshake). One implementation of the
+ * CRUD means one key, one shape, and every mutation is a fresh
+ * read-modify-write — ending the duplicated-CRUD / last-write-wins drift the
+ * old copies in index.html and arcade-p2p.js had.
+ *
+ * Entry shape (per deviceId):
+ *   { name, remoteName, firstConnectedAt, lastConnectedAt, timesConnected,
+ *     fingerprint, fingerprintChangedAt?, autoReconnect? }
+ */
+
+export const KNOWN_PEERS_KEY = 'arcade.v1._meta.knownPeers';
+
+export function readKnownPeers() {
+    try {
+        const raw = localStorage.getItem(KNOWN_PEERS_KEY);
+        const obj = raw ? JSON.parse(raw) : null;
+        return (obj && typeof obj === 'object') ? obj : {};
+    } catch (e) { return {}; }
+}
+
+export function writeKnownPeers(map) {
+    try { localStorage.setItem(KNOWN_PEERS_KEY, JSON.stringify(map)); } catch (e) {}
+}
+
+/**
+ * Read-modify-write in one place: fn receives the freshly-read map and
+ * returns the map to persist (usually the same object, mutated) — or a
+ * falsy value to abort without writing. Returns whether a write happened.
+ */
+export function mutateKnownPeers(fn) {
+    const map = readKnownPeers();
+    let next;
+    try { next = fn(map); } catch (e) { return false; }
+    if (!next || typeof next !== 'object') return false;
+    writeKnownPeers(next);
+    return true;
+}
+
+/** Set the local, user-editable label for a known peer. */
+export function renameKnownPeer(id, name) {
+    const trimmed = String(name || '').trim().slice(0, 60);
+    if (!trimmed) return false;
+    return mutateKnownPeers((map) => {
+        if (!map[id]) return null;
+        map[id].name = trimmed;
+        return map;
+    });
+}
+
+/** Forget a known peer entirely. */
+export function deleteKnownPeer(id) {
+    return mutateKnownPeers((map) => {
+        if (!map[id]) return null;
+        delete map[id];
+        return map;
+    });
+}

--- a/arcade-p2p.js
+++ b/arcade-p2p.js
@@ -55,6 +55,7 @@
 
 import { RendezvousManager } from './p2p/rendezvous.js';
 import { MqttCarrier } from './p2p/rendezvous-carriers.js';
+import { readKnownPeers, writeKnownPeers } from './arcade-known-peers.js';
 
 // Free public MQTT-over-WSS broker used as the untrusted dead-drop. It sees
 // only ciphertext on unlinkable rotating topics, and only during repair.
@@ -109,7 +110,6 @@ function applyStatus(mp) {
 const META_PREFIX = 'arcade.v1._meta.';
 const DEVICE_ID_KEY = META_PREFIX + 'deviceId';
 const DEVICE_NAME_KEY = META_PREFIX + 'deviceName';
-const KNOWN_PEERS_KEY = META_PREFIX + 'knownPeers';
 const LAST_LIVE_SESSION_KEY = META_PREFIX + 'lastLiveSession';
 const DEFAULT_DEVICE_NAME = 'My device';
 const RESUME_WINDOW_MS = 6 * 3600 * 1000; // resumeRendezvous freshness window
@@ -139,21 +139,29 @@ function getMyDeviceName() {
     catch (e) { return DEFAULT_DEVICE_NAME; }
 }
 
-function readKnownPeers() {
-    try {
-        const raw = localStorage.getItem(KNOWN_PEERS_KEY);
-        const obj = raw ? JSON.parse(raw) : null;
-        return (obj && typeof obj === 'object') ? obj : {};
-    } catch (e) { return {}; }
-}
-
-function writeKnownPeers(map) {
-    try { localStorage.setItem(KNOWN_PEERS_KEY, JSON.stringify(map)); } catch (e) {}
-}
-
 const peerIdentityListeners = []; // fn({deviceId, name, remoteName, isNew, fingerprintChanged})
 const pairRequestListeners = [];  // fn({deviceId, name}) — peer wants auto-reconnect, user undecided
+const presenceListeners = [];     // fn({gameId, deviceId, name, kind}) — remote game mounted/listening
 const identityLinks = new Map();  // deviceId → transport peerId of its DIRECT link
+
+function deviceIdForPeerId(peerId) {
+    for (const [devId, pid] of identityLinks) {
+        if (pid === peerId) return devId;
+    }
+    return null;
+}
+
+// deviceIds whose direct-link fingerprint changed this session. A peer-chosen
+// deviceId must never silently capture another device's auto-reconnect slot:
+// while a deviceId is suspect, the pairing secret is NOT re-derived and
+// stored-flag pair requests fall back to asking the user. Cleared only by an
+// explicit user decision (enableAutoReconnect).
+const fingerprintSuspects = new Set();
+
+// deviceIds are machine-generated on the honest path: either a UUID
+// (crypto.randomUUID) or the 'dev-' fallback. Anything else is a peer making
+// ids up — reject before it can touch knownPeers or the reconnect machinery.
+const DEVICE_ID_RE = /^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|dev-[a-z0-9]{6,50})$/i;
 
 function stampLiveSession() {
     try { localStorage.setItem(LAST_LIVE_SESSION_KEY, String(Date.now())); } catch (e) {}
@@ -169,7 +177,7 @@ function stampLiveSession() {
  * "tell the user", never "silently trust" and never "silently block".
  */
 function recordPeerIdentity(deviceId, remoteName, fingerprint) {
-    if (typeof deviceId !== 'string' || !deviceId) return null;
+    if (typeof deviceId !== 'string' || deviceId.length > 64 || !DEVICE_ID_RE.test(deviceId)) return null;
     const safeRemoteName = (typeof remoteName === 'string' && remoteName.trim())
         ? remoteName.trim().slice(0, 60) : 'Unnamed device';
     const safeFp = (typeof fingerprint === 'string' && /^[0-9A-F]{2}(:[0-9A-F]{2}){19,63}$/.test(fingerprint)) ? fingerprint : null;
@@ -283,24 +291,57 @@ async function ensureAddon() {
             }
         });
 
-        // Identity frames are handled at the TRANSPORT level, where the
-        // sending link's peerId — and therefore its DTLS fingerprint — is
-        // available. Only a direct (non-relayed) identity may bind a
+        // ALL arcade envelopes are handled at the TRANSPORT level, where the
+        // sending link's peerId is available — identity frames need it for
+        // the DTLS fingerprint, and game/presence frames need it to name the
+        // sending device. Only a direct (non-relayed) identity may bind a
         // fingerprint; a relayed one still records the name.
         mp.peerNode.addEventListener('message', (e) => {
             const d = e.detail || {};
             if (!d.incoming) return;
             let env = null;
             try { env = JSON.parse(d.text); } catch (err) { return; }
-            if (!env || env.arcade !== 1 || env.kind !== 'identity') return;
+            if (!env || env.arcade !== 1) return;
+            if (env.kind === 'presence' || env.kind === 'presence-ack') {
+                // The remote launcher says a game with this gameId is mounted
+                // and listening over there.
+                if (typeof env.gameId !== 'string') return;
+                const presDeviceId = deviceIdForPeerId(d.peerId);
+                const knownNow = readKnownPeers();
+                const presName = (presDeviceId && knownNow[presDeviceId] && knownNow[presDeviceId].name)
+                    || 'Unnamed device';
+                for (const fn of presenceListeners) {
+                    try { fn({ gameId: env.gameId, deviceId: presDeviceId, name: presName, kind: env.kind }); }
+                    catch (err) {}
+                }
+                return;
+            }
+            if (env.kind !== 'identity') {
+                // A game's message. Route by gameId, attributing the sending
+                // device when its identity handshake has completed.
+                if (typeof env.gameId !== 'string') return;
+                const fromDeviceId = deviceIdForPeerId(d.peerId);
+                for (const fn of messageListeners) {
+                    try { fn(env.gameId, env.payload, fromDeviceId); } catch (err) {}
+                }
+                return;
+            }
             const fp = d.relayed ? null : mp.peerNode.getPeerFingerprint(d.peerId);
-            recordPeerIdentity(env.deviceId, env.name, fp);
+            const detail = recordPeerIdentity(env.deviceId, env.name, fp);
+            if (!detail) return; // malformed deviceId — bind nothing
             if (!d.relayed) {
                 identityLinks.set(env.deviceId, d.peerId);
+                if (detail.fingerprintChanged) fingerprintSuspects.add(env.deviceId);
                 // A manual ceremony with an auto-reconnect peer is a fresh
-                // trust event: re-establish the pairing secret every time.
+                // trust event: re-establish the pairing secret every time —
+                // UNLESS this link's fingerprint mismatches the pinned one.
+                // A changed fingerprint on a known deviceId is exactly what a
+                // peer claiming another device's id looks like, so the rebind
+                // waits for an explicit user decision (the launcher confirms
+                // via onPeerIdentity's fingerprintChanged flag).
                 const known = readKnownPeers();
-                if (known[env.deviceId] && known[env.deviceId].autoReconnect && rdv) {
+                if (known[env.deviceId] && known[env.deviceId].autoReconnect && rdv
+                        && !fingerprintSuspects.has(env.deviceId)) {
                     rdv.enablePair(d.peerId, env.deviceId).catch(() => {});
                     stampLiveSession();
                 }
@@ -331,25 +372,20 @@ async function ensureAddon() {
             if (!deviceId) return;
             const known = readKnownPeers();
             const flag = known[deviceId] && known[deviceId].autoReconnect;
-            if (flag === true) {
+            if (flag === true && !fingerprintSuspects.has(deviceId)) {
                 rdv.enablePair(peerId, deviceId).catch(() => {});
-            } else if (flag === undefined) {
+            } else if (flag === undefined || (flag === true && fingerprintSuspects.has(deviceId))) {
+                // Undecided — or decided, but this link's fingerprint changed
+                // since the flag was stored. Either way the user re-confirms.
                 for (const fn of pairRequestListeners) {
                     try { fn({ deviceId, name: (known[deviceId] && known[deviceId].name) || 'Unnamed device' }); } catch (err) {}
                 }
             } // flag === false → user declined; stay silent
         });
 
-        // 'data' fires with JSON already parsed when possible.
-        mp.addEventListener('data', (e) => {
-            const env = e.detail;
-            if (!env || typeof env !== 'object' || env.arcade !== 1) return;
-            if (env.kind === 'identity') return; // handled on the transport listener above
-            if (typeof env.gameId !== 'string') return;
-            for (const fn of messageListeners) {
-                try { fn(env.gameId, env.payload); } catch (err) {}
-            }
-        });
+        // Game messages are routed on the transport 'message' listener above
+        // (the addon's parsed 'data' event has no peerId, so it can't
+        // attribute a sender).
 
         addon = mp;
         return mp;
@@ -376,13 +412,82 @@ export const ArcadeP2P = {
         };
     },
 
-    /** Subscribe to inbound game messages: fn(gameId, payload). */
+    /**
+     * Subscribe to inbound game messages: fn(gameId, payload, fromDeviceId).
+     * fromDeviceId is the sending device's stable id (null until its identity
+     * handshake completes — a beat after 'connected').
+     */
     onMessage(fn) {
         messageListeners.push(fn);
         return () => {
             const i = messageListeners.indexOf(fn);
             if (i >= 0) messageListeners.splice(i, 1);
         };
+    },
+
+    /**
+     * Presence: fires when the remote launcher announces that a game with a
+     * given gameId is mounted and listening — fn({gameId, deviceId, name,
+     * kind}). kind 'presence' expects an ack (announceGame(gameId, true))
+     * when we have the same game mounted; 'presence-ack' is the echo.
+     */
+    onPresence(fn) {
+        presenceListeners.push(fn);
+        return () => {
+            const i = presenceListeners.indexOf(fn);
+            if (i >= 0) presenceListeners.splice(i, 1);
+        };
+    },
+
+    /**
+     * Tell the remote launcher a game with this gameId is mounted and
+     * listening here. isAck answers a received 'presence' (no further reply,
+     * so the two-frame exchange terminates).
+     */
+    announceGame(gameId, isAck) {
+        if (!addon || (sdkStatus !== 'connected' && sdkStatus !== 'interrupted')) return false;
+        if (typeof gameId !== 'string' || !gameId) return false;
+        addon.send({ arcade: 1, kind: isAck ? 'presence-ack' : 'presence', gameId });
+        return true;
+    },
+
+    /**
+     * Live remote devices whose identity handshake completed:
+     * [{deviceId, name}]. Used to seed a freshly-mounted game's roster.
+     */
+    connectedPeers() {
+        if (!addon) return [];
+        const known = readKnownPeers();
+        const out = [];
+        for (const [deviceId, peerId] of identityLinks) {
+            const p = addon.peerNode.peers.get(peerId);
+            if (p && (p.status === 'connected' || p.status === 'interrupted')) {
+                out.push({ deviceId, name: (known[deviceId] && known[deviceId].name) || 'Unnamed device' });
+            }
+        }
+        return out;
+    },
+
+    /**
+     * Replay-queue visibility: { depth, limit, overflowed }. depth is the
+     * deepest per-link outbox (live links and rendezvous-stashed sessions);
+     * overflowed means the transport already dropped the oldest unacked
+     * messages and games should resync state after recovery.
+     */
+    queueSnapshot() {
+        if (!addon) return { depth: 0, limit: 0, overflowed: false };
+        let depth = 0, overflowed = false;
+        addon.peerNode.peers.forEach((p) => {
+            depth = Math.max(depth, (p.outbox || []).length);
+            if (p.outboxOverflowed) overflowed = true;
+        });
+        if (addon.peerNode.sessionStash) {
+            addon.peerNode.sessionStash.forEach((s) => {
+                depth = Math.max(depth, (s.outbox || []).length);
+                if (s.outboxOverflowed) overflowed = true;
+            });
+        }
+        return { depth, limit: (addon.peerNode.options && addon.peerNode.options.outboxLimit) || 1000, overflowed };
     },
 
     /**
@@ -443,6 +548,9 @@ export const ArcadeP2P = {
         if (!known[deviceId]) return false;
         known[deviceId].autoReconnect = true;
         writeKnownPeers(known);
+        // Explicit user decision — re-trust this device even if its
+        // fingerprint changed this session.
+        fingerprintSuspects.delete(deviceId);
         const peerId = identityLinks.get(deviceId);
         if (rdv && peerId) {
             await rdv.enablePair(peerId, deviceId).catch(() => {});

--- a/arcade-sdk.js
+++ b/arcade-sdk.js
@@ -15,12 +15,14 @@
  * API
  *   Arcade.init({ gameId })        identity + handshake (sync)
  *   Arcade.ready                   Promise resolved on welcome / standalone
- *   Arcade.context                 { framed, version, gameId }
+ *   Arcade.context                 { framed, version, gameId, suspended }
  *
  *   // Storage — sync, JSON-encoded under arcade.v1.<gameId>.<key>
  *   Arcade.state.get / set / remove
+ *   Arcade.state.set(key, v, { exportable: false })  keep out of save files
  *   Arcade.state.getOrInit(key, defaults)         deep-merge load
  *   Arcade.state.migrate(version, fn)             run-once bootstrap
+ *   Arcade.state.adopt(legacyKey, newKey?, opts?) one-line legacy-key move
  *   Arcade.state.onChange(key, fn)                storage events + replace
  *
  *   // Cross-game keys under arcade.v1.global.<key>
@@ -29,8 +31,20 @@
  *   // Sticky display name (lives in arcade.v1.global.playerName)
  *   Arcade.player.name() / setName(s) / onChange(fn)
  *
- *   // Lifecycle (driven by launcher iframe pool)
+ *   // Lifecycle — launcher iframe pool when framed, page visibility
+ *   // standalone; both sources are merged into one deduplicated stream.
  *   Arcade.onSuspend(fn) / onResume(fn) / onStateReplaced(fn)
+ *   Arcade.context.suspended                      current effective state
+ *   (<html data-arcade-suspended="true|false"> mirrors it for CSS/late code)
+ *
+ *   // Managed rAF loop — cancels on suspend, resumes if it was running,
+ *   // suspended time never appears in a delta
+ *   const loop = Arcade.loop((deltaMs, ts) => { ... });
+ *   loop.start() / stop() / kick() / running() / dispose()
+ *
+ *   // Suspend-aware timers — freeze on suspend (remaining time preserved),
+ *   // cancel on stateReplaced; both return { cancel() }
+ *   Arcade.session.setTimeout(fn, ms) / Arcade.session.setInterval(fn, ms)
  *
  *   // Settings — pushed by launcher; SDK auto-applies CSS hooks
  *   Arcade.settings.fontScale | theme | reducedMotion | audioVolume | handedness
@@ -39,14 +53,19 @@
  *
  *   // Multiplayer (no-ops standalone)
  *   Arcade.peer.status / onStatus / send / onMessage
+ *   Arcade.peer.self() / remote()                 stable device identities
+ *   Arcade.peer.onReady(fn)                       remote same-game listening
+ *   Arcade.peer.sendBlob(blob, { onProgress }) / onBlob(fn)
+ *   Arcade.peer.queue() / onQueue(fn)             replay-queue visibility
  *
  *   // Launcher-mediated UI
  *   Arcade.ui.toast(message, { kind, duration })
  *
  *   // Top-N leaderboard per category
- *   Arcade.scores.add(category, { score, name?, meta? })
+ *   Arcade.scores.add(category, { score, name?, key?, meta? }, { order? })
+ *                                  order: 'desc' (default) | 'asc' (times)
  *   Arcade.scores.list(category, { limit }?)
- *   Arcade.scores.best(category)
+ *   Arcade.scores.best(category) / best(category, key)   keyed bests
  *   Arcade.scores.clear(category)
  *
  *   // Mutable per-category counter / blob
@@ -99,16 +118,84 @@
     var listeners = {
         peerStatus: [],
         peerMessage: [],
+        peerReady: [],
+        peerQueue: [],
+        peerBlob: [],
         stateReplaced: [],
         settingsChange: [],
         suspend: [],
         resume: []
     };
+
+    // Remote peer roster — seeded from the launcher's welcome, kept fresh by
+    // arcade:peer.identity / arcade:peer.ready broadcasts.
+    var remotePeers = {}; // deviceId -> { deviceId, name, at }
+    function noteRemotePeer(deviceId, name) {
+        if (typeof deviceId !== 'string' || !deviceId || deviceId.length > 64) return null;
+        var prev = remotePeers[deviceId];
+        var rec = {
+            deviceId: deviceId,
+            name: (typeof name === 'string' && name) ? name.slice(0, 60)
+                : (prev ? prev.name : 'Unnamed device'),
+            at: Date.now()
+        };
+        remotePeers[deviceId] = rec;
+        return rec;
+    }
+    // Last-known transport replay-queue snapshot (pushed by the launcher —
+    // meaningful during 'interrupted' episodes).
+    var peerQueueSnapshot = { depth: 0, limit: 0, overflowed: false };
     var keyChangeListeners = new Map(); // fullKey -> [fn, fn, ...]
 
     var readyResolved = false;
     var readyResolve;
     var readyPromise = new Promise(function (r) { readyResolve = r; });
+
+    // ─── Suspend state ────────────────────────────────────────────
+    // Two independent suspend sources, OR'd into one effective state:
+    //   - launcherSuspended: the launcher hid/evicted this iframe
+    //     (arcade:lifecycle.* messages — framed only)
+    //   - pageSuspended: this document itself is hidden (visibilitychange /
+    //     pagehide — the only signal that exists standalone, and the one the
+    //     launcher does NOT deliver for tab/window hide)
+    // Games see a single deduplicated suspend/resume stream; the current
+    // state is readable at any time via Arcade.context.suspended and the
+    // data-arcade-suspended attribute on <html> (a hidden iframe's own
+    // document.visibilityState stays 'visible', so code mounted mid-session
+    // has no other way to know).
+    var launcherSuspended = false;
+    var pageSuspended = false;
+    var suspendedNow = false;
+
+    function applySuspendedToDOM() {
+        try {
+            document.documentElement.setAttribute(
+                'data-arcade-suspended', suspendedNow ? 'true' : 'false');
+        } catch (e) {}
+    }
+    function recomputeSuspended() {
+        var next = launcherSuspended || pageSuspended;
+        if (next === suspendedNow) return;
+        suspendedNow = next;
+        applySuspendedToDOM();
+        fire(next ? listeners.suspend : listeners.resume);
+    }
+    function installPageLifecycle() {
+        try {
+            document.addEventListener('visibilitychange', function () {
+                pageSuspended = document.visibilityState === 'hidden';
+                recomputeSuspended();
+            });
+            window.addEventListener('pagehide', function () {
+                pageSuspended = true;
+                recomputeSuspended();
+            });
+            window.addEventListener('pageshow', function () {
+                pageSuspended = document.visibilityState === 'hidden';
+                recomputeSuspended();
+            });
+        } catch (e) {}
+    }
 
     // ─── Helpers ──────────────────────────────────────────────────
     function inIframe() {
@@ -138,11 +225,26 @@
     function isPlainObject(o) {
         return o !== null && typeof o === 'object' && !Array.isArray(o);
     }
+    // Merge helper hardened against prototype pollution: stored values come
+    // from JSON.parse, which creates '__proto__' as an own enumerable key —
+    // naive `out[k] = v` on that key fires the prototype setter. Own keys
+    // only, dunder keys skipped.
+    function isDunderKey(k) {
+        return k === '__proto__' || k === 'constructor' || k === 'prototype';
+    }
     function deepMerge(base, override) {
         if (!isPlainObject(base) || !isPlainObject(override)) return override;
         var out = {};
-        for (var k in base) out[k] = base[k];
-        for (var k2 in override) {
+        var baseKeys = Object.keys(base);
+        for (var i = 0; i < baseKeys.length; i++) {
+            var k = baseKeys[i];
+            if (isDunderKey(k)) continue;
+            out[k] = base[k];
+        }
+        var overrideKeys = Object.keys(override);
+        for (var j = 0; j < overrideKeys.length; j++) {
+            var k2 = overrideKeys[j];
+            if (isDunderKey(k2)) continue;
             var ov = override[k2], bv = base[k2];
             out[k2] = (isPlainObject(bv) && isPlainObject(ov)) ? deepMerge(bv, ov) : ov;
         }
@@ -234,6 +336,7 @@
             d.style.setProperty('--audio-volume', settings.audioVolume);
             d.setAttribute('data-theme', settings.theme);
             d.setAttribute('data-handedness', settings.handedness);
+            d.setAttribute('data-reduced-motion', settings.reducedMotion ? 'true' : 'false');
         } catch (e) {}
     }
     // Inject a default rem-scaling rule before any game CSS so games that don't
@@ -248,7 +351,19 @@
             style.id = 'arcade-sdk-base-style';
             style.textContent =
                 ':root{font-size:calc(100% * var(--font-scale, 1));' +
-                '--motion-scale:1;--audio-volume:1;}';
+                '--motion-scale:1;--audio-volume:1;}\n' +
+                // Reduced-motion kill switch: when the launcher (or OS)
+                // requests reduced motion, CSS animations/transitions
+                // collapse to a single instant frame — no per-game calc()
+                // rewrites needed. A game that manages motion itself opts
+                // out by setting data-arcade-keep-motion on <html>.
+                ':root[data-reduced-motion="true"]:not([data-arcade-keep-motion]) *,' +
+                ':root[data-reduced-motion="true"]:not([data-arcade-keep-motion]) *::before,' +
+                ':root[data-reduced-motion="true"]:not([data-arcade-keep-motion]) *::after{' +
+                'animation-duration:.001ms!important;' +
+                'animation-iteration-count:1!important;' +
+                'transition-duration:.001ms!important;' +
+                'scroll-behavior:auto!important;}';
             head.insertBefore(style, head.firstChild);
         } catch (e) {}
     }
@@ -300,6 +415,60 @@
         } catch (e) {}
     }
 
+    // ─── Blob transfer (over Arcade.peer.send) ────────────────────
+    // Large payloads ride the ordered/reliable data channel as a sequence of
+    // base64 chunks wrapped in { __arcadeBlob: {...} } envelopes. Chunk
+    // payloads are intercepted before onMessage listeners, so games only see
+    // whole blobs via onBlob.
+    var BLOB_CHUNK_BYTES = 48 * 1024;
+    var BLOB_MAX_CHUNKS = 2048; // ~96 MB — reject anything claiming more
+    var blobSendCounter = 0;
+    var blobRx = {}; // id -> { chunks, received, total, mime, name }
+
+    function bytesToBase64(bytes) {
+        var bin = '';
+        for (var i = 0; i < bytes.length; i += 0x8000) {
+            bin += String.fromCharCode.apply(null, bytes.subarray(i, i + 0x8000));
+        }
+        return btoa(bin);
+    }
+    function base64ToBytes(b64) {
+        var bin = atob(b64);
+        var out = new Uint8Array(bin.length);
+        for (var i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+        return out;
+    }
+    function handleBlobChunk(meta, fromPeer) {
+        if (!meta || typeof meta.id !== 'string' || meta.id.length > 64) return;
+        if (typeof meta.seq !== 'number' || typeof meta.total !== 'number') return;
+        if (meta.total < 1 || meta.total > BLOB_MAX_CHUNKS
+                || meta.seq < 0 || meta.seq >= meta.total || meta.seq !== Math.floor(meta.seq)) return;
+        var st = blobRx[meta.id];
+        if (!st) {
+            st = blobRx[meta.id] = {
+                chunks: new Array(meta.total),
+                received: 0,
+                total: meta.total,
+                mime: typeof meta.mime === 'string' ? meta.mime.slice(0, 128) : '',
+                name: typeof meta.name === 'string' ? meta.name.slice(0, 128) : ''
+            };
+        }
+        if (st.total !== meta.total || st.chunks[meta.seq] !== undefined) return;
+        var bytes;
+        try { bytes = base64ToBytes(String(meta.bytes || '')); }
+        catch (e) { delete blobRx[meta.id]; return; }
+        st.chunks[meta.seq] = bytes;
+        st.received++;
+        if (st.received === st.total) {
+            delete blobRx[meta.id];
+            var blob;
+            try { blob = new Blob(st.chunks, { type: st.mime }); } catch (e) { return; }
+            fire(listeners.peerBlob, blob, {
+                name: st.name, size: blob.size, mime: st.mime, fromPeer: fromPeer, id: meta.id
+            });
+        }
+    }
+
     // ─── postMessage protocol ─────────────────────────────────────
     function postToParent(msg) {
         if (!framed) return;
@@ -332,14 +501,43 @@
                 framed = true;
                 parentOrigin = e.origin;
                 setPeerStatus(typeof data.peerStatus === 'string' ? data.peerStatus : 'idle');
+                if (Array.isArray(data.peers)) {
+                    for (var pi = 0; pi < data.peers.length; pi++) {
+                        var p = data.peers[pi];
+                        if (p && typeof p === 'object') noteRemotePeer(p.deviceId, p.name);
+                    }
+                }
                 if (applySettings(data.settings)) fire(listeners.settingsChange, snapshotSettings());
                 resolveReady();
                 break;
             case 'arcade:peer.message':
+                if (data.payload && typeof data.payload === 'object' && data.payload.__arcadeBlob) {
+                    handleBlobChunk(data.payload.__arcadeBlob, data.fromPeer);
+                    break;
+                }
                 fire(listeners.peerMessage, data.payload, data.fromPeer);
                 break;
             case 'arcade:peer.status':
                 if (typeof data.status === 'string') setPeerStatus(data.status);
+                break;
+            case 'arcade:peer.identity':
+                noteRemotePeer(data.deviceId, data.name);
+                break;
+            case 'arcade:peer.ready': {
+                var readyRec = noteRemotePeer(data.deviceId, data.name);
+                fire(listeners.peerReady,
+                    readyRec ? { deviceId: readyRec.deviceId, name: readyRec.name } : {});
+                break;
+            }
+            case 'arcade:peer.queue':
+                if (typeof data.depth === 'number' && data.depth >= 0) {
+                    peerQueueSnapshot = {
+                        depth: data.depth,
+                        limit: typeof data.limit === 'number' ? data.limit : 0,
+                        overflowed: data.overflowed === true
+                    };
+                    fire(listeners.peerQueue, peerApi.queue());
+                }
                 break;
             case 'arcade:state.replaced':
                 fire(listeners.stateReplaced);
@@ -356,10 +554,12 @@
                 if (applySettings(data.settings)) fire(listeners.settingsChange, snapshotSettings());
                 break;
             case 'arcade:lifecycle.suspend':
-                fire(listeners.suspend);
+                launcherSuspended = true;
+                recomputeSuspended();
                 break;
             case 'arcade:lifecycle.resume':
-                fire(listeners.resume);
+                launcherSuspended = false;
+                recomputeSuspended();
                 break;
         }
     }
@@ -376,20 +576,43 @@
         }
     }
 
-    // ─── Service-worker collision warning ─────────────────────────
+    // ─── Service-worker collision check ───────────────────────────
+    // Inspects the origin's shared CacheStorage for launcher-root assets
+    // sitting in a NON-launcher cache — the definitive symptom of a game SW
+    // caching files outside its own /<gameId>/ scope. (A workerStart-based
+    // probe can't tell a scope-filtered pass-through from actual caching:
+    // every request from a controlled page routes through the SW.)
+    // The launcher's own cache names start with 'paul-arcade-'.
+    var LAUNCHER_CACHE_PREFIX = 'paul-arcade-';
+    var LAUNCHER_ROOT_ASSETS = ['/', '/index.html', '/arcade-sdk.js', '/arcade-p2p.js', '/styles.css'];
     function checkSWCollision() {
         try {
-            if (!navigator.serviceWorker || !navigator.serviceWorker.controller) return;
-            var script = document.currentScript;
-            var url = script ? script.src : null;
-            if (!url || url.indexOf('arcade-sdk.js') === -1) return;
-            var entries = (performance.getEntriesByName ? performance.getEntriesByName(url) : []);
-            if (entries && entries.length > 0 && entries[0].workerStart > 0) {
-                console.warn(
-                    '[Arcade SDK] arcade-sdk.js was served from a service worker. ' +
-                    'Games must NOT cache the SDK in their own SW — see GAME_INTEGRATION.md §7.'
-                );
-            }
+            if (typeof caches === 'undefined' || !caches.keys) return;
+            caches.keys().then(function (names) {
+                var offenders = [];
+                var work = [];
+                names.forEach(function (name) {
+                    if (name.indexOf(LAUNCHER_CACHE_PREFIX) === 0) return;
+                    work.push(caches.open(name).then(function (cache) {
+                        return Promise.all(LAUNCHER_ROOT_ASSETS.map(function (path) {
+                            return cache.match(path).then(function (hit) {
+                                if (hit) offenders.push('"' + name + '" caches ' + path);
+                            }, function () {});
+                        }));
+                    }, function () {}));
+                });
+                return Promise.all(work).then(function () {
+                    if (!offenders.length) return;
+                    var msg = '[Arcade SDK] A game service worker cached launcher-root assets: '
+                        + offenders.join('; ')
+                        + '. Scope your SW to /<gameId>/ and never cache the SDK or other '
+                        + 'launcher files — see GAME_INTEGRATION.md §10.';
+                    console.error(msg);
+                    if (devModeOn()) {
+                        showFallbackToast('SW scope violation — this game\'s service worker caches launcher files (see console)', 'error', 8000);
+                    }
+                });
+            }).catch(function () {});
         } catch (e) {}
     }
 
@@ -406,6 +629,8 @@
         honorDevQueryParam();
         injectBaseStyle();
         hydrateSettingsFromStorage();
+        applySuspendedToDOM();
+        installPageLifecycle();
         try { window.addEventListener('storage', onStorage); } catch (e) {}
         // Keep the cached settings + DOM hooks in sync when global keys change
         // in another iframe (same-origin storage events fire automatically).
@@ -445,17 +670,42 @@
     }
 
     // ─── State (per-game) ─────────────────────────────────────────
+    // Save-export governance: keys written with { exportable: false } are
+    // listed (by full localStorage key) in arcade.v1.<gameId>._noExport; the
+    // launcher's export skips them. For bulky local-only data (telemetry,
+    // caches) that should never inflate every save file.
+    function noExportListKey() { return gameKey('_noExport'); }
+    function setKeyExportable(fullKey, exportable) {
+        var list = readJSON(noExportListKey());
+        if (!Array.isArray(list)) list = [];
+        var i = list.indexOf(fullKey);
+        if (!exportable && i === -1) {
+            list.push(fullKey);
+            writeJSON(noExportListKey(), list);
+        } else if (exportable && i !== -1) {
+            list.splice(i, 1);
+            writeJSON(noExportListKey(), list.length ? list : undefined);
+        }
+    }
     var stateApi = {
         get: function (key) { ensureGameId(); return readJSON(gameKey(key)); },
-        set: function (key, value) {
+        // opts.exportable (boolean, sticky): false excludes this key from
+        // launcher save files until a later set passes { exportable: true }.
+        set: function (key, value, opts) {
             ensureGameId();
             var k = gameKey(key);
-            if (writeJSON(k, value)) fireKeyChange(k, value);
+            if (writeJSON(k, value)) {
+                if (opts && typeof opts.exportable === 'boolean') {
+                    setKeyExportable(k, opts.exportable);
+                }
+                fireKeyChange(k, value);
+            }
         },
         remove: function (key) {
             ensureGameId();
             var k = gameKey(key);
             removeKey(k);
+            setKeyExportable(k, true); // drop any stale no-export entry
             fireKeyChange(k, null);
         },
         // Read with defaults. If nothing is stored, write defaults. If a value
@@ -495,6 +745,36 @@
                 return false;
             }
             writeJSON(sentinel, true);
+            return true;
+        },
+        // Adopt a legacy (non-namespaced) localStorage key into the game's
+        // namespace: read → namespaced write → delete original. Error-safe:
+        // the original is only deleted after a successful write, and an
+        // existing namespaced value is never clobbered (the legacy key is
+        // just cleaned up). With { json: false } the raw string is stored
+        // as a string value instead of being JSON.parsed first.
+        // Returns true if a legacy value was found and handled.
+        adopt: function (legacyKey, newKey, opts) {
+            ensureGameId();
+            if (typeof legacyKey !== 'string' || !legacyKey) {
+                throw new Error('Arcade.state.adopt: legacyKey must be a non-empty string');
+            }
+            var targetKey = (typeof newKey === 'string' && newKey) ? newKey : legacyKey;
+            var raw;
+            try { raw = localStorage.getItem(legacyKey); } catch (e) { return false; }
+            if (raw === null) return false;
+            var k = gameKey(targetKey);
+            var existing;
+            try { existing = localStorage.getItem(k); } catch (e) { existing = null; }
+            if (existing === null) {
+                var value = raw;
+                if (!opts || opts.json !== false) {
+                    try { value = JSON.parse(raw); } catch (e) { /* keep raw string */ }
+                }
+                if (!writeJSON(k, value)) return false; // quota — keep the original
+                fireKeyChange(k, value);
+            }
+            removeKey(legacyKey);
             return true;
         },
         onChange: function (key, fn) {
@@ -555,7 +835,84 @@
             postToParent({ type: 'arcade:peer.send', payload: payload });
             return true;
         },
-        onMessage: makeSubscriber(listeners.peerMessage)
+        onMessage: makeSubscriber(listeners.peerMessage),
+
+        // This device's stable identity — the same deviceId the launcher
+        // uses for known peers / auto-reconnect. null until the launcher's
+        // P2P layer has generated one (i.e. before the first ever pairing).
+        self: function () {
+            try {
+                var id = localStorage.getItem(KEY_PREFIX + '_meta.deviceId');
+                if (!id) return null;
+                var name = localStorage.getItem(KEY_PREFIX + '_meta.deviceName');
+                return { deviceId: id, name: name || 'My device' };
+            } catch (e) { return null; }
+        },
+        // Most recently seen remote device ({ deviceId, name }) or null.
+        remote: function () {
+            var best = null;
+            for (var k in remotePeers) {
+                if (!best || remotePeers[k].at > best.at) best = remotePeers[k];
+            }
+            return best ? { deviceId: best.deviceId, name: best.name } : null;
+        },
+        // Fires when the remote device has THIS game mounted and listening —
+        // fn({ deviceId, name }). May fire more than once per session (both
+        // sides announce); treat it as an idempotent "peer is ready" signal.
+        // Replaces the hand-rolled hello/echo handshake games used to need.
+        onReady: makeSubscriber(listeners.peerReady),
+
+        // Send a Blob/File to the peer, chunked over the ordered channel.
+        // Resolves { id, chunks, size } after the last chunk is handed to
+        // the transport; opts.onProgress(fraction, sent, total) per chunk.
+        sendBlob: function (blob, opts) {
+            if (!blob || typeof blob.arrayBuffer !== 'function') {
+                return Promise.reject(new Error('Arcade.peer.sendBlob: pass a Blob or File'));
+            }
+            var onProgress = (opts && typeof opts.onProgress === 'function') ? opts.onProgress : null;
+            var name = (opts && typeof opts.name === 'string' && opts.name) ? opts.name
+                : (typeof blob.name === 'string' ? blob.name : '');
+            return blob.arrayBuffer().then(function (buf) {
+                var bytes = new Uint8Array(buf);
+                var total = Math.max(1, Math.ceil(bytes.length / BLOB_CHUNK_BYTES));
+                if (total > BLOB_MAX_CHUNKS) {
+                    throw new Error('Arcade.peer.sendBlob: blob too large ('
+                        + bytes.length + ' bytes; max ' + (BLOB_MAX_CHUNKS * BLOB_CHUNK_BYTES) + ')');
+                }
+                var id = 'b' + (++blobSendCounter) + '-' + Date.now().toString(36);
+                for (var seq = 0; seq < total; seq++) {
+                    var chunk = bytes.subarray(seq * BLOB_CHUNK_BYTES, (seq + 1) * BLOB_CHUNK_BYTES);
+                    var ok = peerApi.send({
+                        __arcadeBlob: {
+                            id: id, seq: seq, total: total, size: bytes.length,
+                            mime: blob.type || '', name: name.slice(0, 128),
+                            bytes: bytesToBase64(chunk)
+                        }
+                    });
+                    if (!ok) throw new Error('Arcade.peer.sendBlob: no live connection');
+                    if (onProgress) {
+                        try { onProgress((seq + 1) / total, seq + 1, total); } catch (e) {}
+                    }
+                }
+                return { id: id, chunks: total, size: bytes.length };
+            });
+        },
+        // fn(blob, { name, size, mime, fromPeer, id }) once a full blob has
+        // been reassembled.
+        onBlob: makeSubscriber(listeners.peerBlob),
+
+        // Transport replay-queue visibility: { depth, limit, overflowed }.
+        // depth grows while 'interrupted' (sends queue for replay); when
+        // overflowed is true the oldest unacknowledged messages were dropped
+        // and the game should resync authoritative state after recovery.
+        queue: function () {
+            return {
+                depth: peerQueueSnapshot.depth,
+                limit: peerQueueSnapshot.limit,
+                overflowed: peerQueueSnapshot.overflowed
+            };
+        },
+        onQueue: makeSubscriber(listeners.peerQueue)
     };
 
     // ─── UI ───────────────────────────────────────────────────────
@@ -606,7 +963,12 @@
     // ─── Scores (per category) ────────────────────────────────────
     function scoresKey(category) { return gameKey('scores.' + category); }
     var scoresApi = {
-        add: function (category, entry) {
+        // opts.order: 'desc' (default — higher is better) or 'asc' (lower is
+        // better: times, move counts). Pass the same order on every add for a
+        // category; the whole list is re-sorted with the order given here.
+        // entry.key (optional string): a label for keyed bests — e.g. a board
+        // code — queried via scores.best(category, key).
+        add: function (category, entry, opts) {
             ensureGameId();
             if (typeof category !== 'string' || !category) {
                 throw new Error('Arcade.scores.add: category required');
@@ -615,6 +977,7 @@
                     || typeof entry.score !== 'number' || !isFinite(entry.score)) {
                 throw new Error('Arcade.scores.add: entry.score must be a finite number');
             }
+            var order = (opts && opts.order === 'asc') ? 'asc' : 'desc';
             var record = {
                 score: entry.score,
                 ts: typeof entry.ts === 'number' ? entry.ts : Date.now()
@@ -625,6 +988,9 @@
                 var pn = playerApi.name();
                 if (pn) record.name = pn;
             }
+            if (typeof entry.key === 'string' && entry.key) {
+                record.key = entry.key.slice(0, 64);
+            }
             if (entry.meta && typeof entry.meta === 'object') {
                 record.meta = entry.meta;
             }
@@ -632,7 +998,9 @@
             var list = readJSON(k);
             if (!Array.isArray(list)) list = [];
             list.push(record);
-            list.sort(function (a, b) { return b.score - a.score; });
+            list.sort(function (a, b) {
+                return order === 'asc' ? a.score - b.score : b.score - a.score;
+            });
             if (list.length > SCORES_CAP) list.length = SCORES_CAP;
             writeJSON(k, list);
             fireKeyChange(k, list);
@@ -646,9 +1014,21 @@
             var limit = (opts && typeof opts.limit === 'number') ? opts.limit : SCORES_DEFAULT_LIMIT;
             return list.slice(0, Math.max(0, limit));
         },
-        best: function (category) {
-            var l = scoresApi.list(category, { limit: 1 });
-            return l.length ? l[0] : null;
+        // best(category) → top entry. best(category, key) → best entry whose
+        // record.key matches (the list is stored best-first, so the first
+        // match wins under either sort order).
+        best: function (category, key) {
+            if (key === undefined) {
+                var l = scoresApi.list(category, { limit: 1 });
+                return l.length ? l[0] : null;
+            }
+            ensureGameId();
+            var list = readJSON(scoresKey(category));
+            if (!Array.isArray(list)) return null;
+            for (var i = 0; i < list.length; i++) {
+                if (list[i] && list[i].key === key) return list[i];
+            }
+            return null;
         },
         clear: function (category) {
             ensureGameId();
@@ -809,19 +1189,167 @@
         };
         return tracker;
     }
+    // ─── Suspend-aware scheduling ─────────────────────────────────
+    // setTimeout/setInterval variants that freeze while the game is
+    // suspended (remaining time is preserved and re-armed on resume) and
+    // cancel themselves when the launcher imports a save (stateReplaced) —
+    // a callback armed against pre-import state must not fire against
+    // post-import state.
+    function nowMs() {
+        return (typeof performance !== 'undefined' && performance.now)
+            ? performance.now() : Date.now();
+    }
+    function createManagedTimer(fn, ms, repeat) {
+        if (typeof fn !== 'function') {
+            throw new Error('Arcade.session.' + (repeat ? 'setInterval' : 'setTimeout') + ': fn must be a function');
+        }
+        var interval = Math.max(0, Number(ms) || 0);
+        var remaining = interval;
+        var id = null;
+        var armedAt = null;
+        var done = false;
+
+        function arm() {
+            armedAt = nowMs();
+            id = setTimeout(fireIt, remaining);
+        }
+        function disarm() {
+            if (id === null) return;
+            clearTimeout(id);
+            id = null;
+            remaining = Math.max(0, remaining - (nowMs() - armedAt));
+        }
+        function fireIt() {
+            id = null;
+            if (repeat) {
+                remaining = interval;
+                try { fn(); } catch (e) {}
+                if (!done && !suspendedNow) arm();
+            } else {
+                done = true;
+                detach();
+                try { fn(); } catch (e) {}
+            }
+        }
+        function detach() {
+            unsubSuspend();
+            unsubResume();
+            unsubReplaced();
+        }
+        var unsubSuspend = makeSubscriber(listeners.suspend)(function () {
+            if (!done) disarm();
+        });
+        var unsubResume = makeSubscriber(listeners.resume)(function () {
+            if (!done && id === null) arm();
+        });
+        var unsubReplaced = makeSubscriber(listeners.stateReplaced)(function () {
+            if (done) return;
+            done = true;
+            if (id !== null) { clearTimeout(id); id = null; }
+            detach();
+        });
+
+        if (!suspendedNow) arm(); // created while suspended → starts frozen
+
+        return {
+            cancel: function () {
+                if (done) return;
+                done = true;
+                if (id !== null) { clearTimeout(id); id = null; }
+                detach();
+            }
+        };
+    }
+
     var sessionApi = {
         start: function (options) {
             ensureGameId();
             return createSessionTimer(options);
+        },
+        setTimeout: function (fn, ms) {
+            ensureGameId();
+            return createManagedTimer(fn, ms, false);
+        },
+        setInterval: function (fn, ms) {
+            ensureGameId();
+            return createManagedTimer(fn, ms, true);
         }
     };
+
+    // ─── Managed rAF loop ─────────────────────────────────────────
+    // Every canvas game re-implements "cancel rAF on suspend, re-request on
+    // resume" and someone always gets one leg wrong. Arcade.loop(fn) owns
+    // that: fn(deltaMs, ts) runs once per animation frame while started and
+    // not suspended; suspended time never appears in a delta (the first
+    // frame after resume gets delta 0).
+    function createLoop(fn) {
+        if (typeof fn !== 'function') {
+            throw new Error('Arcade.loop: fn must be a function');
+        }
+        var rafId = null;
+        var running = false;   // caller intent — survives suspend/resume
+        var lastTs = null;
+
+        function schedule() {
+            if (rafId === null && running && !suspendedNow) {
+                rafId = requestAnimationFrame(frame);
+            }
+        }
+        function frame(ts) {
+            rafId = null;
+            if (!running || suspendedNow) return;
+            var delta = lastTs === null ? 0 : ts - lastTs;
+            lastTs = ts;
+            schedule(); // before fn, so a throwing frame doesn't kill the loop
+            fn(delta, ts);
+        }
+        var unsubSuspend = makeSubscriber(listeners.suspend)(function () {
+            if (rafId !== null) { cancelAnimationFrame(rafId); rafId = null; }
+            lastTs = null;
+        });
+        var unsubResume = makeSubscriber(listeners.resume)(function () {
+            lastTs = null;
+            schedule(); // no-op unless start() was called and stop() wasn't
+        });
+
+        var loop = {
+            start: function () { running = true; lastTs = null; schedule(); return loop; },
+            stop: function () {
+                running = false;
+                lastTs = null;
+                if (rafId !== null) { cancelAnimationFrame(rafId); rafId = null; }
+                return loop;
+            },
+            // One frame on demand — for dirty-flag renderers that are
+            // normally stopped. If the loop is started, this is just an
+            // immediate extra scheduling opportunity.
+            kick: function () {
+                if (rafId !== null || suspendedNow) return loop;
+                rafId = requestAnimationFrame(function (ts) {
+                    rafId = null;
+                    if (suspendedNow) return;
+                    if (running) { frame(ts); return; }
+                    fn(0, ts);
+                });
+                return loop;
+            },
+            running: function () { return running; },
+            dispose: function () {
+                loop.stop();
+                unsubSuspend();
+                unsubResume();
+                return null;
+            }
+        };
+        return loop;
+    }
 
     // ─── Public surface ───────────────────────────────────────────
     var api = {
         init: init,
         get ready() { return readyPromise; },
         get context() {
-            return { framed: framed, version: VERSION, gameId: gameId };
+            return { framed: framed, version: VERSION, gameId: gameId, suspended: suspendedNow };
         },
         state: stateApi,
         global: globalApi,
@@ -832,6 +1360,7 @@
         scores: scoresApi,
         stats: statsApi,
         session: sessionApi,
+        loop: function (fn) { ensureGameId(); return createLoop(fn); },
         onSuspend: makeSubscriber(listeners.suspend),
         onResume: makeSubscriber(listeners.resume),
         onStateReplaced: makeSubscriber(listeners.stateReplaced),

--- a/dev.sh
+++ b/dev.sh
@@ -52,6 +52,18 @@ sed_inplace() {
   mv "$tmp" "$file"
 }
 
+# Echo the gameId a game declares via Arcade.init({ gameId: '...' }) in its
+# index.html, or nothing if none is found. The checkout's directory name is
+# NOT authoritative — a repo cloned as ../sow-duku must still mount at the
+# /sowduku/ slug the launcher buttons and acceptance runner use.
+detect_game_id() {
+  local html="$1/index.html"
+  [ -f "$html" ] || return 0
+  grep -oE "Arcade[.]init[(][[:space:]]*[{][[:space:]]*gameId[[:space:]]*:[[:space:]]*['\"][A-Za-z0-9_-]+['\"]" "$html" 2>/dev/null \
+    | head -1 \
+    | sed -E "s/.*['\"]([A-Za-z0-9_-]+)['\"]\$/\1/"
+}
+
 # Returns 0 if $1/package.json declares a "build" script.
 has_build_script() {
   python3 - "$1" <<'PY' 2>/dev/null
@@ -78,14 +90,19 @@ fi
 # ─── usage ─────────────────────────────────────────────────────────────
 if [ "$#" -eq 0 ]; then
   cat <<EOF >&2
-Usage: ./dev.sh <game-dir>... | stop
+Usage: ./dev.sh <game-dir>[:<gameId>]... | stop
 
 Stages the launcher and one or more sibling game repos under a single
 same-origin HTTP server so the SDK handshake works end-to-end locally.
 
+Each game mounts at /<gameId>/, where <gameId> is (in priority order) the
+explicit :<gameId> suffix, the id declared by Arcade.init({ gameId }) in the
+game's index.html, or the directory basename.
+
 Examples:
   ./dev.sh ../si-syn
   ./dev.sh ../si-syn ../pi-game
+  ./dev.sh ../sow-duku-checkout:sowduku
   ./dev.sh stop
 
 Env:
@@ -97,9 +114,27 @@ fi
 # ─── preflight ─────────────────────────────────────────────────────────
 command -v python3 >/dev/null 2>&1 || { echo "dev: python3 required" >&2; exit 1; }
 
+# Split an argument of the form <dir>[:<gameId>] — override lands in
+# ARG_OVERRIDE, directory in ARG_DIR. A ':' only counts as an override
+# separator when the whole argument isn't itself a directory (paths with
+# colons are legal, if exotic).
+split_game_arg() {
+  ARG_DIR="$1"
+  ARG_OVERRIDE=""
+  if [ ! -d "$1" ]; then
+    case "$1" in
+      *:*)
+        ARG_DIR="${1%:*}"
+        ARG_OVERRIDE="${1##*:}"
+        ;;
+    esac
+  fi
+}
+
 for arg in "$@"; do
-  if [ ! -d "$arg" ]; then
-    echo "dev: not a directory: $arg" >&2
+  split_game_arg "$arg"
+  if [ ! -d "$ARG_DIR" ]; then
+    echo "dev: not a directory: $ARG_DIR" >&2
     exit 1
   fi
 done
@@ -116,7 +151,7 @@ mkdir -p "$STAGE_DIR"
 # Rewrite https://paulgibeault.github.io → local origin in HTML/JS/JSON.
 # Skip sw.js — the launcher itself opts out on loopback, and we don't want
 # stale launcher assets cached during dev.
-for f in index.html profile.html manifest.json arcade-sdk.js styles.css arcade-p2p.js; do
+for f in index.html profile.html manifest.json arcade-sdk.js styles.css arcade-p2p.js arcade-known-peers.js; do
   src="$LAUNCHER_DIR/$f"
   if [ -f "$src" ]; then
     sed "s|https://paulgibeault.github.io|$LOCAL_ORIGIN|g" "$src" > "$STAGE_DIR/$f"
@@ -128,28 +163,42 @@ ln -snf "$LAUNCHER_DIR/images" "$STAGE_DIR/images"
 ln -snf "$LAUNCHER_DIR/p2p" "$STAGE_DIR/p2p"
 
 # ─── stage each game ───────────────────────────────────────────────────
+STAGED_IDS=""
 for arg in "$@"; do
-  game_dir="$(cd "$arg" && pwd)"
-  game_id="$(basename "$game_dir")"
-  echo "→ Game: $game_id  ($game_dir)"
+  split_game_arg "$arg"
+  game_dir="$(cd "$ARG_DIR" && pwd)"
+  dir_name="$(basename "$game_dir")"
 
   build_root="$game_dir"
   if has_build_script "$game_dir"; then
     if [ ! -d "$game_dir/node_modules" ]; then
-      echo "dev: $game_id has a build script but no node_modules — run 'npm install' there first" >&2
+      echo "dev: $dir_name has a build script but no node_modules — run 'npm install' there first" >&2
       exit 1
     fi
-    echo "  → npm run build"
+    echo "→ $dir_name: npm run build"
     (cd "$game_dir" && npm run build > /dev/null)
     if [ -d "$game_dir/dist" ]; then
       build_root="$game_dir/dist"
     elif [ -d "$game_dir/build" ]; then
       build_root="$game_dir/build"
     else
-      echo "dev: $game_id built but no dist/ or build/ output found" >&2
+      echo "dev: $dir_name built but no dist/ or build/ output found" >&2
       exit 1
     fi
   fi
+
+  # Mount point: explicit override > Arcade.init gameId > directory basename.
+  if [ -n "$ARG_OVERRIDE" ]; then
+    game_id="$ARG_OVERRIDE"
+  else
+    game_id="$(detect_game_id "$build_root")"
+    if [ -z "$game_id" ]; then
+      game_id="$dir_name"
+    elif [ "$game_id" != "$dir_name" ]; then
+      echo "  → mounting at /$game_id/ (Arcade.init gameId; dir is '$dir_name')"
+    fi
+  fi
+  echo "→ Game: $game_id  ($game_dir)"
 
   cp -R "$build_root" "$STAGE_DIR/$game_id"
   # Older games may still hard-code the absolute SDK URL; rewrite for parity
@@ -157,6 +206,7 @@ for arg in "$@"; do
   if [ -f "$STAGE_DIR/$game_id/index.html" ]; then
     sed_inplace "s|https://paulgibeault.github.io|$LOCAL_ORIGIN|g" "$STAGE_DIR/$game_id/index.html"
   fi
+  STAGED_IDS="$STAGED_IDS $game_id"
 done
 
 # ─── start server ──────────────────────────────────────────────────────
@@ -172,8 +222,7 @@ fi
 
 echo
 echo "  Launcher:  $LOCAL_ORIGIN/"
-for arg in "$@"; do
-  game_id="$(basename "$(cd "$arg" && pwd)")"
+for game_id in $STAGED_IDS; do
   echo "  Game:      $LOCAL_ORIGIN/$game_id/   (standalone)"
 done
 echo "  SDK:       $LOCAL_ORIGIN/arcade-sdk.js"

--- a/index.html
+++ b/index.html
@@ -383,14 +383,6 @@
                     <p class="launcher-btn__subtitle">Cozy Logic Puzzle</p>
                 </div>
             </a>
-            <!-- TEMP local-dev only — not yet a real release, remove before pushing -->
-            <a href="https://paulgibeault.github.io/p2p-chat/" class="launcher-btn" data-game-id="p2p-chat" style="animation-delay: 0.6s">
-                <div class="launcher-btn__image-wrap"><img class="launcher-btn__image" src="images/p2p-chat.png" alt="P2P Chat"></div>
-                <div class="launcher-btn__body">
-                    <h3 class="launcher-btn__name">P2P Chat</h3>
-                    <p class="launcher-btn__subtitle">Multiplayer Demo</p>
-                </div>
-            </a>
         </div>
     </div>
 
@@ -419,6 +411,36 @@
 </div>
 
 <script>
+    // ==========================================
+    // window.__arcade — the one cross-controller surface.
+    // Constructed exactly once, here, with every slot listed so the shape is
+    // greppable in one place. The controller IIFEs below (and the Known
+    // Peers module script at the bottom of the page) fill in their slots as
+    // they run; consumers null-check because some slots (p2p) stay empty
+    // until the lazy bridge loads.
+    // ==========================================
+    window.__arcade = {
+        // fontControl
+        getFontScale: null,
+        // knownPeers module (bottom of page)
+        renderKnownPeers: null,
+        renamePeer: null,
+        // appMenu
+        launcherMenu: null,
+        closeLauncherMenu: null,
+        // gameViewController
+        viewGame: null,
+        viewLauncher: null,
+        // platformController
+        hideGameView: null,
+        applyPoolCap: null,
+        showGame: null,
+        openMultiplayerPanel: null,
+        loadP2P: null,
+        broadcastSettings: null,
+        p2p: null
+    };
+
     // ==========================================
     // STARFIELD — Dense animated twinkling stars
     // ==========================================
@@ -503,7 +525,6 @@
         }
         bind('menu-font-decrease', 'menu-font-increase', 'menu-font-reset');
 
-        window.__arcade = window.__arcade || {};
         window.__arcade.getFontScale = function () { return scale; };
     })();
 
@@ -552,172 +573,6 @@
         input.addEventListener('keydown', (e) => {
             if (e.key === 'Enter') { e.preventDefault(); input.blur(); }
         });
-    })();
-
-    // ==========================================
-    // KNOWN PEERS — name, rename, delete previously-connected devices.
-    // Pure localStorage CRUD (arcade.v1._meta.deviceName / .knownPeers) so
-    // the panel is instant and doesn't force-load the P2P bridge module. The
-    // bridge (arcade-p2p.js) is the only writer of NEW entries — it records
-    // one on every identity handshake once a real connection opens — and
-    // pushes a live refresh here via ArcadeP2P.onPeerIdentity (wired in the
-    // platformController's loadP2P(), since that's the only place the bridge
-    // is ever imported).
-    // ==========================================
-    (function knownPeersController() {
-        const DEVICE_NAME_KEY = 'arcade.v1._meta.deviceName';
-        const KNOWN_PEERS_KEY = 'arcade.v1._meta.knownPeers';
-
-        const nameInput = document.getElementById('menu-device-name-input');
-        const heading = document.getElementById('menu-known-peers-heading');
-        const list = document.getElementById('menu-known-peers-list');
-        if (!nameInput || !heading || !list) return;
-
-        function readKnownPeers() {
-            try {
-                const raw = localStorage.getItem(KNOWN_PEERS_KEY);
-                const obj = raw ? JSON.parse(raw) : null;
-                return (obj && typeof obj === 'object') ? obj : {};
-            } catch (e) { return {}; }
-        }
-        function writeKnownPeers(map) {
-            try { localStorage.setItem(KNOWN_PEERS_KEY, JSON.stringify(map)); } catch (e) {}
-        }
-        function renamePeer(id, name) {
-            const trimmed = String(name || '').trim().slice(0, 60);
-            if (!trimmed) return false;
-            const map = readKnownPeers();
-            if (!map[id]) return false;
-            map[id].name = trimmed;
-            writeKnownPeers(map);
-            render();
-            return true;
-        }
-        function relativeTime(iso) {
-            const then = Date.parse(iso);
-            if (!isFinite(then)) return 'a while ago';
-            const mins = Math.round((Date.now() - then) / 60000);
-            if (mins < 1) return 'just now';
-            if (mins < 60) return mins + 'm ago';
-            const hours = Math.round(mins / 60);
-            if (hours < 24) return hours + 'h ago';
-            return Math.round(hours / 24) + 'd ago';
-        }
-
-        function render() {
-            const known = readKnownPeers();
-            const ids = Object.keys(known).sort((a, b) =>
-                Date.parse(known[b].lastConnectedAt || 0) - Date.parse(known[a].lastConnectedAt || 0));
-            list.innerHTML = '';
-            heading.hidden = ids.length === 0;
-            if (ids.length === 0) {
-                const empty = document.createElement('div');
-                empty.className = 'launcher-menu__peer-empty';
-                empty.textContent = 'Connect to a device to remember it here.';
-                list.appendChild(empty);
-                return;
-            }
-            for (const id of ids) {
-                const peer = known[id];
-                const displayName = peer.name || 'Unnamed device';
-
-                const row = document.createElement('div');
-                row.className = 'launcher-menu__peer-row';
-                row.tabIndex = 0;
-                row.setAttribute('role', 'button');
-                row.setAttribute('aria-label', 'Reconnect to ' + displayName);
-                row.title = 'Reconnect — get a fresh invite code to show or send';
-                row.addEventListener('click', () => {
-                    // One-tap reconnect: skip the Host/Join choice and put a
-                    // fresh invite code on screen immediately. The other
-                    // device joins by scanning it or tapping the sent link.
-                    if (window.__arcade.openMultiplayerPanel) window.__arcade.openMultiplayerPanel({ mode: 'host' });
-                });
-                row.addEventListener('keydown', (e) => {
-                    if (e.key !== 'Enter' && e.key !== ' ') return;
-                    e.preventDefault();
-                    row.click();
-                });
-
-                const info = document.createElement('div');
-                info.className = 'launcher-menu__peer-info';
-                const nameEl = document.createElement('span');
-                nameEl.className = 'launcher-menu__peer-name';
-                nameEl.textContent = displayName;
-                const metaEl = document.createElement('span');
-                metaEl.className = 'launcher-menu__peer-meta';
-                metaEl.textContent = 'Last connected ' + relativeTime(peer.lastConnectedAt);
-                info.appendChild(nameEl);
-                info.appendChild(metaEl);
-
-                const autoBtn = document.createElement('button');
-                autoBtn.type = 'button';
-                autoBtn.className = 'launcher-menu__peer-btn';
-                const autoOn = peer.autoReconnect === true;
-                autoBtn.textContent = autoOn ? '🔁' : '🚫';
-                autoBtn.title = autoOn
-                    ? 'Auto-reconnect is ON — tap to turn off'
-                    : 'Auto-reconnect is OFF — tap to turn on (takes effect next time you connect)';
-                autoBtn.setAttribute('aria-label', (autoOn ? 'Disable' : 'Enable') + ' auto-reconnect for ' + displayName);
-                autoBtn.addEventListener('click', (e) => {
-                    e.stopPropagation();
-                    loadP2P().then((b) => autoOn ? b.disableAutoReconnect(id) : b.enableAutoReconnect(id))
-                        .then(() => render()).catch(() => {});
-                });
-
-                const renameBtn = document.createElement('button');
-                renameBtn.type = 'button';
-                renameBtn.className = 'launcher-menu__peer-btn';
-                renameBtn.title = 'Rename';
-                renameBtn.setAttribute('aria-label', 'Rename ' + displayName);
-                renameBtn.textContent = '✎';
-                renameBtn.addEventListener('click', (e) => {
-                    e.stopPropagation();
-                    const next = window.prompt('Rename this connection:', displayName);
-                    if (next === null) return;
-                    renamePeer(id, next);
-                });
-
-                const deleteBtn = document.createElement('button');
-                deleteBtn.type = 'button';
-                deleteBtn.className = 'launcher-menu__peer-btn';
-                deleteBtn.title = 'Delete';
-                deleteBtn.setAttribute('aria-label', 'Delete ' + displayName);
-                deleteBtn.textContent = '✕';
-                deleteBtn.addEventListener('click', (e) => {
-                    e.stopPropagation();
-                    if (!window.confirm('Forget "' + displayName + '"?')) return;
-                    const map = readKnownPeers();
-                    delete map[id];
-                    writeKnownPeers(map);
-                    render();
-                });
-
-                row.appendChild(info);
-                row.appendChild(autoBtn);
-                row.appendChild(renameBtn);
-                row.appendChild(deleteBtn);
-                list.appendChild(row);
-            }
-        }
-
-        try { nameInput.value = localStorage.getItem(DEVICE_NAME_KEY) || ''; } catch (e) {}
-        nameInput.addEventListener('change', () => {
-            const trimmed = nameInput.value.trim().slice(0, 60);
-            try {
-                if (trimmed) localStorage.setItem(DEVICE_NAME_KEY, trimmed);
-                else localStorage.removeItem(DEVICE_NAME_KEY);
-            } catch (e) {}
-            nameInput.value = trimmed;
-        });
-        nameInput.addEventListener('keydown', (e) => {
-            if (e.key === 'Enter') { e.preventDefault(); nameInput.blur(); }
-        });
-
-        render();
-        window.__arcade = window.__arcade || {};
-        window.__arcade.renderKnownPeers = render; // live-refresh hook for the P2P bridge
-        window.__arcade.renamePeer = renamePeer;    // used to accept/edit a new-connection's suggested name
     })();
 
     // ==========================================
@@ -773,7 +628,6 @@
             if (item && !item.disabled) close();
         });
 
-        window.__arcade = window.__arcade || {};
         window.__arcade.launcherMenu = menu;
         window.__arcade.closeLauncherMenu = close;
     })();
@@ -781,7 +635,6 @@
     // ==========================================
     // GAME VIEW CONTROLLER — Show/hide fullscreen game iframe
     // ==========================================
-    window.__arcade = window.__arcade || {};
     (function gameViewController() {
         const viewLauncher = document.getElementById('view-launcher');
         const viewGame = document.getElementById('view-game');
@@ -805,6 +658,18 @@
         // Anything outside this namespace is rejected on import, so an imported
         // file can never poison non-arcade keys on the origin's localStorage.
         const KEY_RE = /^arcade\.v1\.[a-z0-9_-]+(\.[a-zA-Z0-9_.-]+)+$/;
+        // Dunder path segments are rejected outright: keys are inert in
+        // localStorage, but game code walks key paths and merges stored
+        // values, so a save file must never smuggle prototype-polluting
+        // segments past the allowlist.
+        const DUNDER_SEGMENTS = new Set(['__proto__', 'constructor', 'prototype']);
+        function isSafeArcadeKey(k) {
+            if (!KEY_RE.test(k)) return false;
+            for (const seg of k.split('.')) {
+                if (DUNDER_SEGMENTS.has(seg)) return false;
+            }
+            return true;
+        }
         const SAVE_FORMAT = 'pauls-arcade-save';
         const SAVE_SCHEMA = 1;
         const MAX_IMPORT_BYTES = 5 * 1024 * 1024;
@@ -845,6 +710,10 @@
         // context, and WebGL context. Persistent state lives in
         // arcade.v1.<gameId>.* localStorage and survives.
         const pool = new Map(); // gameId -> { iframe, name }
+        // Games that completed the arcade:hello handshake — i.e. games whose
+        // SDK is actually listening. Presence announcements to the remote
+        // launcher are made only for these.
+        const helloedGames = new Set();
         let activeGameId = null;
         const POOL_CAP_DEFAULT = 2;
 
@@ -878,6 +747,7 @@
                 try { entry.iframe.src = 'about:blank'; } catch (e) {}
                 entry.iframe.remove();
                 pool.delete(lruId);
+                helloedGames.delete(lruId);
             }
         }
 
@@ -961,6 +831,12 @@
                 let prevPeerStatus = 'idle';
                 ArcadeP2P.onStatus((status) => {
                     broadcast({ type: 'arcade:peer.status', status });
+                    // Queue visibility rides along with status transitions —
+                    // games mostly care as an 'interrupted' episode starts
+                    // (depth begins growing) and ends (did it overflow?).
+                    if (status === 'connected' || status === 'interrupted') {
+                        broadcast({ type: 'arcade:peer.queue', ...ArcadeP2P.queueSnapshot() });
+                    }
                     const tag = document.getElementById('menu-multiplayer-status');
                     if (tag) {
                         tag.hidden = status === 'idle';
@@ -970,10 +846,24 @@
                     }
                     if (status === 'connected') {
                         showToast(prevPeerStatus === 'interrupted' ? 'Multiplayer reconnected!' : 'Multiplayer connected!');
+                        // Tell the other launcher which handshaken games are
+                        // mounted here, so its games get a ready signal.
+                        for (const gid of pool.keys()) {
+                            if (helloedGames.has(gid)) ArcadeP2P.announceGame(gid);
+                        }
                     } else if (status === 'interrupted') {
                         showToast('Multiplayer connection interrupted — reconnecting…');
                     }
                     prevPeerStatus = status;
+                });
+                ArcadeP2P.onPresence(({ gameId, deviceId, name, kind }) => {
+                    // The remote launcher has <gameId> mounted and listening.
+                    // If we do too, hand that game a ready event — and answer
+                    // a first announcement with an ack so the remote's game
+                    // learns about us without another round.
+                    if (!pool.has(gameId) || !helloedGames.has(gameId)) return;
+                    postToIframe(gameId, { type: 'arcade:peer.ready', deviceId, name });
+                    if (kind === 'presence') ArcadeP2P.announceGame(gameId, true);
                 });
                 ArcadeP2P.onPeerIdentity(({ deviceId, name, remoteName, isNew, fingerprintChanged }) => {
                     // Identity-pinning notice (TOFU): a changed device
@@ -982,6 +872,18 @@
                     // neither applies, the user should re-verify in person.
                     if (fingerprintChanged) {
                         showToast('⚠️ ' + name + "'s device identity changed since last time. Normal after ~a month or a browser reset — if unexpected, verify in person.", { error: true });
+                        // The bridge refuses to silently rebind the pairing
+                        // secret on a changed fingerprint — auto-reconnect for
+                        // this peer stays parked until the user re-trusts.
+                        if (ArcadeP2P.autoReconnectState(deviceId) === true) {
+                            const keep = window.confirm(
+                                '"' + name + '" reconnected with a changed device identity.\n\n' +
+                                'This is normal after ~a month (browser certificate renewal) or a browser ' +
+                                'reset. If neither applies, someone could be impersonating their device.\n\n' +
+                                'Keep reconnecting to this device automatically?');
+                            if (keep) ArcadeP2P.enableAutoReconnect(deviceId);
+                            else ArcadeP2P.disableAutoReconnect(deviceId);
+                        }
                     }
                     // Arrives a beat after 'connected' (one more data-channel
                     // round trip) — swap the generic tag for the peer's
@@ -991,6 +893,9 @@
                         tag.textContent = name;
                     }
                     if (window.__arcade.renderKnownPeers) window.__arcade.renderKnownPeers();
+                    // Let mounted games update their peer roster
+                    // (Arcade.peer.remote() and friends).
+                    broadcast({ type: 'arcade:peer.identity', deviceId, name });
                     // First time pairing with this device: ask what to call it,
                     // suggesting the name it reported about itself. Declining
                     // (Cancel) just keeps that suggested name as-is.
@@ -1017,14 +922,17 @@
                     // The other device opted in and ours has no stored answer.
                     askAutoReconnect(deviceId, name);
                 });
-                ArcadeP2P.onMessage((targetGameId, payload) => {
+                ArcadeP2P.onMessage((targetGameId, payload, fromDeviceId) => {
                     // Route by the sender's gameId — both devices run the same
                     // game for a session, so target == sender's id. Messages
                     // for unmounted games are dropped (game not running here).
+                    // fromPeer carries the sending device's stable id once its
+                    // identity handshake completed ('peer' for the brief
+                    // window before it, and for older peers that never send one).
                     postToIframe(targetGameId, {
                         type: 'arcade:peer.message',
                         payload: payload,
-                        fromPeer: 'peer'
+                        fromPeer: fromDeviceId || 'peer'
                     });
                 });
                 p2pBridge = ArcadeP2P;
@@ -1043,6 +951,7 @@
             loadP2P().then((b) => b.openUI(options)).catch(() => {});
         }
         window.__arcade.openMultiplayerPanel = openMultiplayerPanel; // shared by the menu item + known-peer rows
+        window.__arcade.loadP2P = loadP2P; // Known Peers auto-reconnect toggle lives in a sibling IIFE
 
         const menuMultiplayer = document.getElementById('menu-multiplayer');
         if (menuMultiplayer) {
@@ -1077,11 +986,11 @@
         });
 
         // ---- postMessage protocol ----
-        function findGameIdForSource(src) {
+        function findPoolEntryForSource(src) {
             for (const [gid, entry] of pool) {
-                if (entry.iframe.contentWindow === src) return gid;
+                if (entry.iframe.contentWindow === src) return [gid, entry];
             }
-            return null;
+            return [null, null];
         }
 
         function postToIframe(gameId, msg) {
@@ -1149,11 +1058,17 @@
         }
 
         window.addEventListener('message', (e) => {
-            // Source check is the load-bearing guard: only iframes we mounted
-            // via ensureIframe can match. Origin may be cross-origin in local
-            // dev (parent on localhost, game on github.io) so we don't gate on it.
-            const gameId = findGameIdForSource(e.source);
+            // Two guards, both load-bearing. Source: only iframes we mounted
+            // via ensureIframe can match. Origin: the sandbox doesn't stop a
+            // frame from navigating ITSELF cross-origin (a stray <a href>
+            // suffices), and afterwards e.source still matches the pool entry
+            // — so we also require the message's origin to equal the origin
+            // captured at mount. Local dev stages games same-origin, and a
+            // cross-origin-mounted game's real origin is what ensureIframe
+            // recorded, so both setups pass without special-casing.
+            const [gameId, entry] = findPoolEntryForSource(e.source);
             if (!gameId) return;
+            if (e.origin !== entry.origin) return;
             const data = e.data;
             if (!data || typeof data !== 'object') return;
             const t = data.type;
@@ -1171,11 +1086,14 @@
                     // Announce ourselves. peerStatus reflects the live bridge
                     // when loaded (a game mounted mid-session must see
                     // 'connected' immediately). Settings ride along so the
-                    // game can apply them before first paint.
+                    // game can apply them before first paint; `peers` seeds
+                    // the game's roster with already-connected devices.
+                    helloedGames.add(gameId);
                     postToIframe(gameId, {
                         type: 'arcade:welcome',
                         version: 2,
                         peerStatus: p2pBridge ? p2pBridge.status() : 'idle',
+                        peers: p2pBridge ? p2pBridge.connectedPeers() : [],
                         settings: currentSettings()
                     });
                     // If this game is the active one, also send a resume hint
@@ -1184,12 +1102,23 @@
                     if (gameId === activeGameId) {
                         postToIframe(gameId, { type: 'arcade:lifecycle.resume' });
                     }
+                    // Presence: tell the remote launcher this game is now
+                    // listening (no-op unless a session is live).
+                    if (p2pBridge) p2pBridge.announceGame(gameId);
                     break;
                 case 'arcade:peer.send':
                     // Wrap in the launcher envelope and ship over the data
                     // channel. The SDK already gates on status==='connected',
                     // so a null bridge here just means a stray message — drop.
-                    if (p2pBridge) p2pBridge.send(gameId, data.payload);
+                    if (p2pBridge) {
+                        p2pBridge.send(gameId, data.payload);
+                        // While a repair episode runs, every queued send comes
+                        // back with a fresh queue-depth reading so the game
+                        // can see how close it is to the replay cap.
+                        if (p2pBridge.status() === 'interrupted') {
+                            postToIframe(gameId, { type: 'arcade:peer.queue', ...p2pBridge.queueSnapshot() });
+                        }
+                    }
                     break;
                 case 'arcade:ui.toast':
                     // Game asked the launcher to display a toast.
@@ -1250,6 +1179,17 @@
         window.__arcade.broadcastSettings = function () {
             broadcast({ type: 'arcade:settings.changed', settings: currentSettings() });
         };
+        // OS-level theme / reduced-motion flips mid-session must reach
+        // mounted games: currentSettings() falls back to matchMedia when the
+        // user has no explicit override, so a change event just re-broadcasts.
+        try {
+            for (const q of ['(prefers-color-scheme: light)', '(prefers-reduced-motion: reduce)']) {
+                const mq = window.matchMedia(q);
+                const rebroadcast = () => window.__arcade.broadcastSettings();
+                if (mq.addEventListener) mq.addEventListener('change', rebroadcast);
+                else if (mq.addListener) mq.addListener(rebroadcast); // older Safari
+            }
+        } catch (e) {}
 
         // ---- toast helper ----
         let toastTimer = null;
@@ -1281,10 +1221,26 @@
         }
 
         function collectArcadeKeys() {
+            // Save-export governance: the SDK's state.set(key, v,
+            // {exportable:false}) lists local-only keys (telemetry, caches)
+            // in arcade.v1.<gameId>._noExport — those never inflate a save.
+            const noExport = new Set();
+            for (let i = 0; i < localStorage.length; i++) {
+                const k = localStorage.key(i);
+                if (!k || !/^arcade\.v1\.[a-z0-9_-]+\._noExport$/.test(k)) continue;
+                try {
+                    const list = JSON.parse(localStorage.getItem(k));
+                    if (Array.isArray(list)) {
+                        for (const item of list) {
+                            if (typeof item === 'string') noExport.add(item);
+                        }
+                    }
+                } catch (e) {}
+            }
             const out = {};
             for (let i = 0; i < localStorage.length; i++) {
                 const k = localStorage.key(i);
-                if (!k || !KEY_RE.test(k)) continue;
+                if (!k || !isSafeArcadeKey(k) || noExport.has(k)) continue;
                 const v = localStorage.getItem(k);
                 if (typeof v === 'string') out[k] = v;
             }
@@ -1415,7 +1371,7 @@
             const cleanData = {};
             const droppedKeys = [];
             for (const k of Object.keys(parsed.data)) {
-                if (!KEY_RE.test(k) || typeof parsed.data[k] !== 'string') {
+                if (!isSafeArcadeKey(k) || typeof parsed.data[k] !== 'string') {
                     droppedKeys.push(k);
                     continue;
                 }
@@ -1435,8 +1391,11 @@
                 showToast('Checksum mismatch — file may be corrupt.', { error: true });
                 return;
             }
-            // Gate 7: confirm with user
-            const summary = 'This will replace ' + cleanKeys.length + ' arcade keys.\n'
+            // Gate 7: confirm with user. Import merges: keys in the file
+            // overwrite their current values, keys NOT in the file are kept
+            // — the copy must say so.
+            const summary = 'This will import ' + cleanKeys.length + ' arcade keys from the file, '
+                + 'overwriting their current values. Saved data not in the file is kept as-is.\n'
                 + (droppedKeys.length ? droppedKeys.length + ' invalid keys will be ignored.\n' : '')
                 + '\nYour current state will be auto-saved to your Downloads folder first.\nContinue?';
             if (!window.confirm(summary)) return;
@@ -1535,6 +1494,158 @@
             deferredPrompt = null;
             hideInstallUI();
         });
+    })();
+</script>
+
+<script type="module">
+    // ==========================================
+    // KNOWN PEERS — name, rename, delete previously-connected devices.
+    // A module so the CRUD comes from arcade-known-peers.js — the single
+    // owner of arcade.v1._meta.knownPeers, shared with the lazy P2P bridge
+    // (which records NEW entries on every identity handshake and pushes a
+    // live refresh here via ArcadeP2P.onPeerIdentity, wired in the
+    // platformController's loadP2P()). The panel itself never force-loads
+    // the bridge just to view/rename/delete.
+    // ==========================================
+    import { readKnownPeers, renameKnownPeer, deleteKnownPeer } from './arcade-known-peers.js';
+
+    (function knownPeersController() {
+        const DEVICE_NAME_KEY = 'arcade.v1._meta.deviceName';
+
+        const nameInput = document.getElementById('menu-device-name-input');
+        const heading = document.getElementById('menu-known-peers-heading');
+        const list = document.getElementById('menu-known-peers-list');
+        if (!nameInput || !heading || !list) return;
+
+        function renamePeer(id, name) {
+            const ok = renameKnownPeer(id, name);
+            if (ok) render();
+            return ok;
+        }
+        function relativeTime(iso) {
+            const then = Date.parse(iso);
+            if (!isFinite(then)) return 'a while ago';
+            const mins = Math.round((Date.now() - then) / 60000);
+            if (mins < 1) return 'just now';
+            if (mins < 60) return mins + 'm ago';
+            const hours = Math.round(mins / 60);
+            if (hours < 24) return hours + 'h ago';
+            return Math.round(hours / 24) + 'd ago';
+        }
+
+        function render() {
+            const known = readKnownPeers();
+            const ids = Object.keys(known).sort((a, b) =>
+                Date.parse(known[b].lastConnectedAt || 0) - Date.parse(known[a].lastConnectedAt || 0));
+            list.innerHTML = '';
+            heading.hidden = ids.length === 0;
+            if (ids.length === 0) {
+                const empty = document.createElement('div');
+                empty.className = 'launcher-menu__peer-empty';
+                empty.textContent = 'Connect to a device to remember it here.';
+                list.appendChild(empty);
+                return;
+            }
+            for (const id of ids) {
+                const peer = known[id];
+                const displayName = peer.name || 'Unnamed device';
+
+                const row = document.createElement('div');
+                row.className = 'launcher-menu__peer-row';
+                row.tabIndex = 0;
+                row.setAttribute('role', 'button');
+                row.setAttribute('aria-label', 'Reconnect to ' + displayName);
+                row.title = 'Reconnect — get a fresh invite code to show or send';
+                row.addEventListener('click', () => {
+                    // One-tap reconnect: skip the Host/Join choice and put a
+                    // fresh invite code on screen immediately. The other
+                    // device joins by scanning it or tapping the sent link.
+                    if (window.__arcade.openMultiplayerPanel) window.__arcade.openMultiplayerPanel({ mode: 'host' });
+                });
+                row.addEventListener('keydown', (e) => {
+                    if (e.key !== 'Enter' && e.key !== ' ') return;
+                    e.preventDefault();
+                    row.click();
+                });
+
+                const info = document.createElement('div');
+                info.className = 'launcher-menu__peer-info';
+                const nameEl = document.createElement('span');
+                nameEl.className = 'launcher-menu__peer-name';
+                nameEl.textContent = displayName;
+                const metaEl = document.createElement('span');
+                metaEl.className = 'launcher-menu__peer-meta';
+                metaEl.textContent = 'Last connected ' + relativeTime(peer.lastConnectedAt);
+                info.appendChild(nameEl);
+                info.appendChild(metaEl);
+
+                const autoBtn = document.createElement('button');
+                autoBtn.type = 'button';
+                autoBtn.className = 'launcher-menu__peer-btn';
+                const autoOn = peer.autoReconnect === true;
+                autoBtn.textContent = autoOn ? '🔁' : '🚫';
+                autoBtn.title = autoOn
+                    ? 'Auto-reconnect is ON — tap to turn off'
+                    : 'Auto-reconnect is OFF — tap to turn on (takes effect next time you connect)';
+                autoBtn.setAttribute('aria-label', (autoOn ? 'Disable' : 'Enable') + ' auto-reconnect for ' + displayName);
+                autoBtn.addEventListener('click', (e) => {
+                    e.stopPropagation();
+                    if (!window.__arcade.loadP2P) return;
+                    window.__arcade.loadP2P()
+                        .then((b) => autoOn ? b.disableAutoReconnect(id) : b.enableAutoReconnect(id))
+                        .then(() => render()).catch(() => {});
+                });
+
+                const renameBtn = document.createElement('button');
+                renameBtn.type = 'button';
+                renameBtn.className = 'launcher-menu__peer-btn';
+                renameBtn.title = 'Rename';
+                renameBtn.setAttribute('aria-label', 'Rename ' + displayName);
+                renameBtn.textContent = '✎';
+                renameBtn.addEventListener('click', (e) => {
+                    e.stopPropagation();
+                    const next = window.prompt('Rename this connection:', displayName);
+                    if (next === null) return;
+                    renamePeer(id, next);
+                });
+
+                const deleteBtn = document.createElement('button');
+                deleteBtn.type = 'button';
+                deleteBtn.className = 'launcher-menu__peer-btn';
+                deleteBtn.title = 'Delete';
+                deleteBtn.setAttribute('aria-label', 'Delete ' + displayName);
+                deleteBtn.textContent = '✕';
+                deleteBtn.addEventListener('click', (e) => {
+                    e.stopPropagation();
+                    if (!window.confirm('Forget "' + displayName + '"?')) return;
+                    deleteKnownPeer(id);
+                    render();
+                });
+
+                row.appendChild(info);
+                row.appendChild(autoBtn);
+                row.appendChild(renameBtn);
+                row.appendChild(deleteBtn);
+                list.appendChild(row);
+            }
+        }
+
+        try { nameInput.value = localStorage.getItem(DEVICE_NAME_KEY) || ''; } catch (e) {}
+        nameInput.addEventListener('change', () => {
+            const trimmed = nameInput.value.trim().slice(0, 60);
+            try {
+                if (trimmed) localStorage.setItem(DEVICE_NAME_KEY, trimmed);
+                else localStorage.removeItem(DEVICE_NAME_KEY);
+            } catch (e) {}
+            nameInput.value = trimmed;
+        });
+        nameInput.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter') { e.preventDefault(); nameInput.blur(); }
+        });
+
+        render();
+        window.__arcade.renderKnownPeers = render; // live-refresh hook for the P2P bridge
+        window.__arcade.renamePeer = renamePeer;    // used to accept/edit a new-connection's suggested name
     })();
 </script>
 

--- a/p2p/p2p-addon.js
+++ b/p2p/p2p-addon.js
@@ -48,9 +48,12 @@ export class P2PAddon extends EventTarget {
             });
         };
 
+        // Vendored copies only (p2p/vendor/) — the launcher must never reach
+        // for a CDN at runtime. loadScript still skips any global that a host
+        // page pre-loaded itself.
         await Promise.all([
-            loadScript("https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js", "QRCode"),
-            loadScript("https://cdnjs.cloudflare.com/ajax/libs/html5-qrcode/2.3.8/html5-qrcode.min.js", "Html5Qrcode")
+            loadScript(new URL('./vendor/qrcode.min.js', import.meta.url).href, "QRCode"),
+            loadScript(new URL('./vendor/html5-qrcode.min.js', import.meta.url).href, "Html5Qrcode")
         ]);
     }
 

--- a/p2p/p2p-ui.js
+++ b/p2p/p2p-ui.js
@@ -1,5 +1,10 @@
 import { ConnectionUtils } from './p2p-core.js';
 
+// Shown in the modal header. Users are told to compare this across devices
+// when a connection fails, so it must track the vendored transport version
+// (see VENDORED.md / upstream PROTOCOL.md) — single constant, no other copies.
+const UI_VERSION_LABEL = 'v1.9';
+
 export class P2PUIManager {
     constructor(peerNode) {
         this.peerNode = peerNode;
@@ -201,6 +206,19 @@ export class P2PUIManager {
                 this.ui.choice.style.display = 'none';
                 this._initStages('joiner');
                 this._setStage(0, 'done'); // their invite arrived (via link)
+
+                // Consent gate: answering an offer starts ICE/STUN toward the
+                // link author's endpoints and broadcasts our answer — enough
+                // to reveal this device's public IP. A crafted link must not
+                // trigger that silently just by being opened.
+                if (!window.confirm(
+                    'Accept this game invite and connect?\n\n' +
+                    'Connecting shares your network address with the person who sent the link. ' +
+                    'If you weren\'t expecting an invite, choose Cancel.')) {
+                    this.logDiag('info', 'Invite declined by user. No connection attempted.');
+                    this.hide();
+                    return;
+                }
 
                 this.logDiag('info', 'Invite link received. Preparing your reply code...');
                 const answerData = await this.peerNode.createAnswer(data);
@@ -458,7 +476,7 @@ export class P2PUIManager {
         <div id="p2p-modal-overlay" class="p2p-modal-overlay" style="display:none;" role="dialog" aria-modal="true" aria-labelledby="p2p-modal-title">
             <div class="p2p-modal">
                 <header class="p2p-header">
-                    <h2 id="p2p-modal-title">Play Together <span style="font-size: 0.5em; color: #888; vertical-align: middle; font-weight: normal; margin-left: 10px;">v1.6.1</span></h2>
+                    <h2 id="p2p-modal-title">Play Together <span style="font-size: 0.5em; color: #888; vertical-align: middle; font-weight: normal; margin-left: 10px;">${UI_VERSION_LABEL}</span></h2>
                     <button id="p2p-btn-close" class="p2p-btn-danger" style="border:none; border-radius:4px; padding:4px 8px; cursor:pointer;" aria-label="Close">X</button>
                 </header>
                 <div id="p2p-status-badge" class="p2p-status-disconnected">Not connected yet</div>

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'paul-arcade-v19';
+const CACHE_NAME = 'paul-arcade-v20';
 const ASSETS_TO_CACHE = [
   './',
   './index.html',
@@ -7,6 +7,7 @@ const ASSETS_TO_CACHE = [
   './manifest.json',
   './arcade-sdk.js',
   './arcade-p2p.js',
+  './arcade-known-peers.js',
   './p2p/p2p-addon.js',
   './p2p/p2p-ui.js',
   './p2p/p2p-core.js',
@@ -24,6 +25,7 @@ const ASSETS_TO_CACHE = [
   './images/hecknsic.png',
   './images/cozy-solitaire.png',
   './images/moon-lit.png',
+  './images/sowduku.png',
   './images/qrcodep2p.png',
   './images/zibaldone.png',
   './images/usai.png'
@@ -54,6 +56,21 @@ self.addEventListener('activate', (event) => {
 });
 
 self.addEventListener('fetch', (event) => {
+  // Only handle launcher-owned URLs: root-level files plus the p2p/ and
+  // images/ trees. Every game lives at /<gameId>/... — those requests fall
+  // through untouched, so a game without its own service worker gets a
+  // normal network error offline instead of an opaque failed cache lookup,
+  // and games with their own SW are never shadowed by this one.
+  const url = new URL(event.request.url);
+  if (url.origin !== self.location.origin) return;
+  const scopePath = new URL(self.registration.scope).pathname;
+  if (!url.pathname.startsWith(scopePath)) return;
+  const rel = url.pathname.slice(scopePath.length);
+  const isLauncherAsset =
+    !rel.includes('/') ||             // '' (root) or a root-level file
+    rel.startsWith('p2p/') ||
+    rel.startsWith('images/');
+  if (!isLauncherAsset) return;
   event.respondWith(
     fetch(event.request).catch(() => caches.match(event.request))
   );

--- a/tools/acceptance.mjs
+++ b/tools/acceptance.mjs
@@ -230,6 +230,45 @@ async function runPerGame() {
 
         await ctx.close();
     }
+
+    // ─── Offline phase (game's own SW, if it registers one) ─────────
+    // GAME_INTEGRATION §10: a game that ships a service worker must cache its
+    // own assets so an offline reload still boots. Games without a SW (or
+    // that skip SW registration on loopback, like the launcher does) are
+    // recorded as skipped, not failed.
+    {
+        const ctx = await browser.newContext();
+        const page = await ctx.newPage();
+        try {
+            await page.goto(gameUrl, { waitUntil: 'load', timeout: 10_000 });
+            // Give install/activate + precache time to settle.
+            await page.waitForTimeout(1500);
+            const regCount = await page.evaluate(async () => {
+                if (!('serviceWorker' in navigator)) return 0;
+                const regs = await navigator.serviceWorker.getRegistrations();
+                return regs.length;
+            });
+            if (regCount === 0) {
+                record(10, 'offline reload via game SW', true, 'no SW registered — skipped');
+            } else {
+                await ctx.setOffline(true);
+                let ok = false, detail = '';
+                try {
+                    await page.reload({ waitUntil: 'load', timeout: 10_000 });
+                    ok = await page.evaluate(() =>
+                        !!(document.body && document.body.children.length > 0));
+                    detail = ok ? '' : 'offline page loaded but rendered nothing';
+                } catch (e) {
+                    detail = `offline reload failed: ${e.message.split('\n')[0]}`;
+                }
+                record(10, 'offline reload via game SW serves cached assets', ok, detail);
+                await ctx.setOffline(false);
+            }
+        } catch (e) {
+            record(10, 'offline reload via game SW', false, `setup failed: ${e.message}`);
+        }
+        await ctx.close();
+    }
 }
 
 // ─── Pool-mode (issue #7): bounded LRU iframe pool ───────────────────

--- a/tools/p2p-acceptance.mjs
+++ b/tools/p2p-acceptance.mjs
@@ -248,10 +248,10 @@ try {
         const rec = window.__arcade.p2p._recordPeerIdentity;
         const fpA = 'AA:' + Array(31).fill('11').join(':');
         const fpB = 'BB:' + Array(31).fill('22').join(':');
-        const first = rec('policy-test-device', 'Pin Tester', fpA);
-        const same = rec('policy-test-device', 'Pin Tester', fpA);
-        const changed = rec('policy-test-device', 'Pin Tester', fpB);
-        const stored = JSON.parse(localStorage.getItem('arcade.v1._meta.knownPeers'))['policy-test-device'];
+        const first = rec('dev-policytest01', 'Pin Tester', fpA);
+        const same = rec('dev-policytest01', 'Pin Tester', fpA);
+        const changed = rec('dev-policytest01', 'Pin Tester', fpB);
+        const stored = JSON.parse(localStorage.getItem('arcade.v1._meta.knownPeers'))['dev-policytest01'];
         return { first: first.fingerprintChanged, same: same.fingerprintChanged,
                  changed: changed.fingerprintChanged, storedFp: stored.fingerprint, changedAt: stored.fingerprintChangedAt };
     });
@@ -259,6 +259,25 @@ try {
     check('re-announce with the same fingerprint stays quiet', policy.same === false);
     check('changed fingerprint is flagged and re-recorded (TOFU-with-notice)',
         policy.changed === true && policy.storedFp.startsWith('BB:') && !!policy.changedAt);
+
+    // 9b. Malformed deviceIds must be rejected before touching knownPeers —
+    //     ids are peer-chosen, so only machine-generated shapes are trusted.
+    const malformed = await H.evaluate(() => {
+        const rec = window.__arcade.p2p._recordPeerIdentity;
+        const fp = 'CC:' + Array(31).fill('33').join(':');
+        const results = [
+            rec('<img src=x onerror=alert(1)>', 'Evil', fp),
+            rec('not a uuid at all', 'Evil', fp),
+            rec('x'.repeat(200), 'Evil', fp),
+            rec(12345, 'Evil', fp)
+        ];
+        const known = JSON.parse(localStorage.getItem('arcade.v1._meta.knownPeers') || '{}');
+        const leaked = Object.keys(known).some(id =>
+            id.includes('<') || id.includes(' ') || id.length > 64);
+        return { allRejected: results.every(r => r === null), leaked };
+    });
+    check('malformed deviceIds are rejected (validation gate)',
+        malformed.allRejected && !malformed.leaked);
 
     // 10. Rendezvous auto-reconnect (PROTOCOL.md §7): both sides opt in,
     //     the connection is killed COMPLETELY, and the session must come
@@ -274,7 +293,7 @@ try {
         });
         await page.evaluate(() => {
             const known = JSON.parse(localStorage.getItem('arcade.v1._meta.knownPeers'));
-            const peerDeviceId = Object.keys(known).find(id => id !== 'policy-test-device');
+            const peerDeviceId = Object.keys(known).find(id => id !== 'dev-policytest01');
             return window.__arcade.p2p.enableAutoReconnect(peerDeviceId);
         });
     }

--- a/tools/templates/game-sw.js
+++ b/tools/templates/game-sw.js
@@ -1,0 +1,69 @@
+/* game-sw.js — reference service worker for Paul's Arcade games.
+ *
+ * Copy this file into your game repo as sw.js (at the repo root, so it lives
+ * inside your scope) and register it from your game's index.html:
+ *
+ *   if ('serviceWorker' in navigator &&
+ *       !/^(127\.|localhost$|0\.0\.0\.0$|::1$)/.test(location.hostname)) {
+ *     navigator.serviceWorker.register('sw.js', { scope: '/YOUR-GAME-ID/' });
+ *   }
+ *
+ * (The loopback guard keeps local-dev edits from being masked by stale
+ * cache, matching the launcher's own behavior.)
+ *
+ * THE TWO RULES — every game and the launcher share ONE origin:
+ *
+ *   1. Never serve or cache anything outside /YOUR-GAME-ID/. The fetch
+ *      handler below early-returns for out-of-scope URLs, so /arcade-sdk.js
+ *      and launcher assets always come from the network (or the launcher's
+ *      own SW). The Arcade SDK reports a console error — and a visible toast
+ *      in ?dev=1 mode — if it finds launcher files in a game's cache.
+ *
+ *   2. Never clean up origin-wide. `caches.keys()` and
+ *      `getRegistrations()` see EVERY game's caches and workers plus the
+ *      launcher's. Delete only cache names you created (the version-keyed
+ *      prefix filter below); never call registration.unregister() on
+ *      registrations that aren't yours.
+ */
+
+const GAME_ID = 'YOUR-GAME-ID';          // must match Arcade.init({ gameId })
+const CACHE_NAME = `${GAME_ID}-v1`;      // bump the suffix on every deploy
+const SCOPE = `/${GAME_ID}/`;
+
+// Everything your game needs to boot offline. All paths must be inside SCOPE.
+const ASSETS = [
+  SCOPE,
+  `${SCOPE}index.html`,
+  // `${SCOPE}main.js`,
+  // `${SCOPE}style.css`,
+  // `${SCOPE}images/...`,
+];
+
+self.addEventListener('install', (event) => {
+  self.skipWaiting();
+  event.waitUntil(caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS)));
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((names) => Promise.all(
+      names
+        .filter((n) => n.startsWith(`${GAME_ID}-`) && n !== CACHE_NAME) // OURS only
+        .map((n) => caches.delete(n))
+    )).then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  const url = new URL(event.request.url);
+  // Scope guard — the load-bearing line. Requests for the SDK, the launcher,
+  // or any other game fall through to the network untouched.
+  if (url.origin !== self.location.origin) return;
+  if (!url.pathname.startsWith(SCOPE)) return;
+
+  // Cache-first for our own assets; network fallback keeps un-listed files
+  // working online.
+  event.respondWith(
+    caches.match(event.request).then((hit) => hit || fetch(event.request))
+  );
+});


### PR DESCRIPTION
Implements issue #17 (from the eight-part platform review) — all of Part A and all of Part B except B11, which the plan itself sequences after hecknsic's `.ls.*` migration ships plus one release.

## Part A — security & correctness

| | Fix |
|---|---|
| **A1** | Inbound `postMessage` now requires `e.origin` to match the origin captured at iframe mount. A frame that navigates itself cross-origin can no longer drive `ls-proxy`, `arcade:peer.send`, or toasts. |
| **A2** | Dunder path segments (`__proto__`/`constructor`/`prototype`) rejected by the import/export key gate; SDK `deepMerge` iterates own keys only and skips dunder keys. Both layers probed: a stored `{"__proto__":{...}}` value no longer pollutes anything. |
| **A3** | `loadP2P` exposed on `window.__arcade`; the Known Peers 🔁/🚫 toggle works instead of throwing `ReferenceError`. |
| **A4** | A changed-fingerprint identity no longer silently rebinds the rendezvous pair secret — the rebind is parked until the user explicitly re-trusts (confirm dialog); `deviceId`s are format-validated (UUID / `dev-` fallback, length-bounded). |
| **A5** | Launcher SW fetch handler path-filters to launcher-owned trees (root files, `p2p/`, `images/`); `/​<gameId>/…` requests fall through to the network. `images/sowduku.png` added to the asset list; cache bumped to v20. |
| **A6** | Opening a `#p2p-offer=` link now asks for consent before `createAnswer` — no more silent ICE/STUN (public-IP disclosure) from a crafted link. |
| **A7** | TEMP `p2p-chat` catalog entry removed (its repo has an unresolved critical stored-XSS issue, so removal over promotion; `gameCount`/pool clamp now reflect shipped games). |
| **A8** | Broker-trust doc line rewritten: content is sealed, but the relay and any wildcard subscriber learn both IPs, the fact of rendezvous, and timing. |
| **A9** | `p2p-addon.js` loads QR libs from `./vendor/` (latent cdnjs URLs gone); modal version label comes from a single constant (`v1.9`). |

## Part B — framework enhancements

- **B1** SW hygiene toolkit: reference worker at `tools/templates/game-sw.js`; §10 gains the copy-paste fetch-guard snippet and the origin-wide-cleanup foot-gun warning; `checkSWCollision` now inspects CacheStorage for launcher assets in game caches (definitive, no workerStart false-positives) and escalates to `console.error` + a visible dev-mode toast; acceptance runner gains an offline-reload check.
- **B2** Suspend/resume fire **standalone** via `visibilitychange`/`pagehide`, merged with launcher lifecycle into one deduplicated stream — fixes cozy/sowduku-class regressions for every game at once.
- **B3** `Arcade.context.suspended` + `data-arcade-suspended` on `<html>` for code mounted mid-session and CSS.
- **B4** `Arcade.loop(fn)` managed rAF loop (auto-cancel on suspend, resume-only-if-running, suspended time excised from deltas) and `Arcade.session.setTimeout/setInterval` (freeze on suspend, cancel on `stateReplaced`).
- **B5** `Arcade.scores.add(cat, entry, { order: 'asc' })` for lower-is-better games + keyed bests (`entry.key`, `best(category, key)`); stats documented as the home for keyed maps.
- **B6** `Arcade.peer.self()/remote()`, `fromPeer` stamped with the real sender deviceId, and a launcher↔launcher presence protocol surfaced as `Arcade.peer.onReady` — retires the hand-rolled hello/echo handshake.
- **B7** `Arcade.peer.sendBlob/onBlob` chunked transfer + replay-queue visibility (`Arcade.peer.queue()/onQueue`, pushed during `interrupted` episodes, `overflowed` flag).
- **B8** `data-reduced-motion` DOM hook + kill-switch rule in the injected base style (opt out via `data-arcade-keep-motion`).
- **B9** `Arcade.state.adopt(legacyKey, newKey)` one-line migrations + §3 docs: treat `onStateReplaced` as a fresh boot; intra-namespace schema-bump example.
- **B10** `dev.sh` mounts each game at the gameId declared by `Arcade.init` (or an explicit `dir:gameId` override) instead of the directory basename — a `../sow-duku` checkout now stages at `/sowduku/`.
- **B12** `Arcade.state.set(key, v, { exportable: false })` keeps bulky local-only keys out of save files (launcher export honors the per-game `_noExport` list); import confirm copy now states merge semantics; `matchMedia` change listeners re-broadcast settings on OS theme/motion flips.
- **B13** (scoped) `window.__arcade` is constructed exactly once with every slot listed; `arcade-known-peers.js` is the single owner of the knownPeers CRUD, shared by the menu panel (now a module) and the P2P bridge. Full ES-module extraction of the platformController remains follow-up work.

**Deferred:** B11 (ls-proxy retirement) per the plan's own sequencing. **Note:** the `p2p/` edits (A6, A9) are in the vendored copy — they should be upstreamed to QRCodeP2P so the next `tools/sync-p2p.sh` doesn't clobber them.

## Verification

- `npm run p2p-acceptance` — **27/27** (two real launchers over a real RTCPeerConnection, including rendezvous auto-reconnect through the dead-drop, plus a new malformed-deviceId rejection check)
- `npm run acceptance` for pi-game and sowduku — **10/10** each (including the new offline-reload check)
- `npm run acceptance -- --pool` with all six games staged — **13/13**, no console errors (covers the module-script Known Peers panel and the new welcome payload)
- Targeted Playwright probes: A2 pollution attempts (stored value + import path), B2/B3 standalone suspend + state hooks, B4 loop/timer freeze-resume semantics, B5 asc/keyed scores, B8 kill rule, B9 adopt, B12 export governance end-to-end — all green
- `node --check` on every touched JS file and both inline `index.html` scripts; `bash -n dev.sh`; dev.sh staging exercised live (auto-detected `sowduku` from a `sow-duku` checkout)

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)