### PR TITLE
fix(p2p): stop relay peer-impersonation and pair-bricking key ratchet

### DIFF
--- a/p2p/p2p-core.js
+++ b/p2p/p2p-core.js
@@ -556,9 +556,18 @@ export class PeerManager extends EventTarget {
         // (identity/fingerprint claims must never bind through a relay).
         // The host always stamps relayed:true itself, so a sender cannot
         // launder a relayed frame into looking direct.
-        if (this.isHost && msg.from !== this.myId) {
+        //
+        // `from` is stamped with the source LINK's peerId — the host-assigned
+        // identifier of the data channel this frame actually arrived on — NOT
+        // the sender-supplied `msg.from`. A client controls its own `msg.from`,
+        // so relaying it verbatim would let any joiner post a message that the
+        // other peers attribute to a different peer. peerId cannot be forged:
+        // it is the key under which this inbound channel is registered.
+        // (Inbound frames are always from a remote client, never the host, so
+        // there is no host-origin frame to exclude here.)
+        if (this.isHost) {
             this.peers.forEach((destData, destId) => {
-                if (destId !== peerId) this._sendAppTo(destId, { text: msg.text, from: msg.from, relayed: true });
+                if (destId !== peerId) this._sendAppTo(destId, { text: msg.text, from: peerId, relayed: true });
             });
         }
 

--- a/p2p/rendezvous.js
+++ b/p2p/rendezvous.js
@@ -943,31 +943,40 @@ export class RendezvousManager extends EventTarget {
     async _settleEpisode(pairId, ep) {
         if (ep.settled) return;
         ep.settled = true;
-        if (ep.exchanged) {
-            // Ratchet — but ONLY for a reconnect that actually went through
-            // the sealed exchange, so both sides advance in lockstep.
-            const own = this.pm.getOwnFingerprint(ep.peerId);
-            const theirs = this.pm.getPeerFingerprint(ep.peerId);
-            if (own && theirs) {
-                ep.rec.base = await RC.ratchet(ep.rec.base, await RC.transcriptHash(own, theirs));
-                ep.rec.epoch = ep.usedEpoch;
-                this._diag(`pair ${pairId}: reconnected via sealed exchange — key ratcheted to epoch ${ep.usedEpoch}`);
-            } else {
-                this._diag(`pair ${pairId}: reconnected but fingerprints unavailable (own=${!!own}, theirs=${!!theirs}) — NOT ratcheting; if the peer ratcheted, the pair is now desynced`, 'warn');
-            }
-        } else {
-            this._diag(`pair ${pairId}: link recovered in-band — episode closed without touching the key`);
-        }
+        // NOTE: the per-reconnect key ratchet is intentionally DISABLED.
+        //
+        // The old design advanced `rec.base` (and `rec.epoch`) on every sealed
+        // reconnect. But each side decided to ratchet independently, from a
+        // purely LOCAL condition (were both DTLS fingerprints available at the
+        // instant this side settled?). There is no agreement step, so any
+        // divergence — one side adopts the sealed connection while the other's
+        // link heals in-band, or fingerprints populate a tick later on one end
+        // — leaves the two sides on DIFFERENT base keys. Because the AEAD key
+        // AND the daily topic both derive from `base`, a base split makes the
+        // pair permanently deaf in both directions (the epoch window cannot
+        // rescue a wrong key on a wrong topic): auto-reconnect bricks the pair
+        // until a manual Start Over + fresh invite on BOTH devices.
+        //
+        // Freezing the secret removes that failure mode outright: both sides
+        // always hold the exact key minted over DTLS at the last MANUAL
+        // ceremony (`_establishPair` re-derives base and resets epoch 0 on both
+        // ends simultaneously — symmetric by construction), and it never
+        // changes underneath either of them during unattended reconnects. The
+        // trade is forward secrecy on the rendezvous *signaling* keys between
+        // manual pairings: those keys now rotate only on an in-person re-pair,
+        // not on every auto-heal. Game traffic is unaffected (separately DTLS-
+        // protected) and topics still rotate daily. Re-enabling a CORRECT
+        // ratchet requires a two-sided commit over the live channel so both
+        // ends advance together or neither does — tracked in the security-
+        // hardening issue, deferred past the current "test what we have" phase.
+        this._diag(ep.exchanged
+            ? `pair ${pairId}: reconnected via sealed exchange — secret held stable (ratchet disabled)`
+            : `pair ${pairId}: link recovered in-band — episode closed without touching the key`);
         ep.rec.lastPeerId = ep.peerId;
         ep.rec.lastSeenAt = Date.now();
         delete ep.rec.byeAt; // reconnected: any old hang-up is history
         try { await dbPut(pairId, ep.rec); } catch (e) {
-            // The ratchet advanced in memory but not on disk: after a restart
-            // this side is on the PREVIOUS base key while the peer moved on —
-            // different AEAD keys AND different topics, so the pair is deaf
-            // in both directions until the next manual ceremony re-mints the
-            // secret. Surface it loudly.
-            this._diag(`pair ${pairId}: FAILED to persist post-reconnect state (${e && e.message}) — the pair will desync across a restart (fix: Start Over + fresh invite on both devices)`, 'error');
+            this._diag(`pair ${pairId}: FAILED to persist post-reconnect state (${e && e.message})`, 'error');
         }
         this._cleanupEpisode(pairId, ep);
         this._emit(ep.exchanged ? 'reconnected' : 'recovered-inband', { pairId, peerId: ep.peerId });

--- a/plans/README.md
+++ b/plans/README.md
@@ -7,16 +7,16 @@ GitHub issue in the corresponding repository.
 
 ## Plans
 
-| Repo | Plan | Theme |
-| ---- | ---- | ----- |
-| `paulgibeault/paulgibeault.github.io` | [framework-launcher.md](framework-launcher.md) | Security fixes + SDK/launcher enhancements the whole fleet needs |
-| `paulgibeault/moon-lit` | [moon-lit.md](moon-lit.md) | Origin-wide SW/cache nuke (critical), suspend containment, stats-delta bug |
-| `paulgibeault/p2p-chat` | [p2p-chat.md](p2p-chat.md) | Stored XSS via peer ids (critical), interrupted-send cap, reduced-motion |
-| `paulgibeault/pi-game` | [pi-game.md](pi-game.md) | Resume rAF freeze, hand-rolled timer, offline SW asset list |
-| `paulgibeault/hecknsic` | [hecknsic.md](hecknsic.md) | SW caches the SDK, orphaned `.ls.*` keys, canvas font-scale |
-| `paulgibeault/si-syn` | [si-syn.md](si-syn.md) | Cinematic timers run while hidden, locked-level rehydrate |
-| `paulgibeault/cozy-solitaire` | [cozy-solitaire.md](cozy-solitaire.md) | Idle clock freeze, standalone flush, dead code |
-| `paulgibeault/sowduku` | [sowduku.md](sowduku.md) | SW caches the SDK, no suspend handling, non-square art, dir/slug |
+| Repo | Plan | Issue | Theme |
+| ---- | ---- | ----- | ----- |
+| `paulgibeault/paulgibeault.github.io` | [framework-launcher.md](framework-launcher.md) | [#17](https://github.com/paulgibeault/paulgibeault.github.io/issues/17) | Security fixes + SDK/launcher enhancements the whole fleet needs |
+| `paulgibeault/moon-lit` | [moon-lit.md](moon-lit.md) | [#20](https://github.com/paulgibeault/moon-lit/issues/20) | Origin-wide SW/cache nuke (critical), suspend containment, stats-delta bug |
+| `paulgibeault/p2p-chat` | [p2p-chat.md](p2p-chat.md) | [#1](https://github.com/paulgibeault/p2p-chat/issues/1) | Stored XSS via peer ids (critical), interrupted-send cap, reduced-motion |
+| `paulgibeault/pi-game` | [pi-game.md](pi-game.md) | [#14](https://github.com/paulgibeault/pi-game/issues/14) | Resume rAF freeze, hand-rolled timer, offline SW asset list |
+| `paulgibeault/hecknsic` | [hecknsic.md](hecknsic.md) | [#38](https://github.com/paulgibeault/hecknsic/issues/38) | SW caches the SDK, orphaned `.ls.*` keys, canvas font-scale |
+| `paulgibeault/si-syn` | [si-syn.md](si-syn.md) | [#17](https://github.com/paulgibeault/si-syn/issues/17) | Cinematic timers run while hidden, locked-level rehydrate |
+| `paulgibeault/cozy-solitaire` | [cozy-solitaire.md](cozy-solitaire.md) | [#7](https://github.com/paulgibeault/cozy-solitaire/issues/7) | Idle clock freeze, standalone flush, dead code |
+| `paulgibeault/sowduku` | [sowduku.md](sowduku.md) | [#1](https://github.com/paulgibeault/sowduku/issues/1) | SW caches the SDK, no suspend handling, non-square art, dir/slug |
 
 ## Two systemic themes (fix once in the framework)
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,0 +1,46 @@
+# Arcade Platform — Remediation Plans
+
+Generated from an eight-part review (2026-07-06) of the Paul's Arcade framework
+(`arcade-sdk.js`, `arcade-p2p.js`, launcher `index.html`, `p2p/`) and every game
+in the launcher catalog. Each plan below is the actionable checklist tracked by a
+GitHub issue in the corresponding repository.
+
+## Plans
+
+| Repo | Plan | Theme |
+| ---- | ---- | ----- |
+| `paulgibeault/paulgibeault.github.io` | [framework-launcher.md](framework-launcher.md) | Security fixes + SDK/launcher enhancements the whole fleet needs |
+| `paulgibeault/moon-lit` | [moon-lit.md](moon-lit.md) | Origin-wide SW/cache nuke (critical), suspend containment, stats-delta bug |
+| `paulgibeault/p2p-chat` | [p2p-chat.md](p2p-chat.md) | Stored XSS via peer ids (critical), interrupted-send cap, reduced-motion |
+| `paulgibeault/pi-game` | [pi-game.md](pi-game.md) | Resume rAF freeze, hand-rolled timer, offline SW asset list |
+| `paulgibeault/hecknsic` | [hecknsic.md](hecknsic.md) | SW caches the SDK, orphaned `.ls.*` keys, canvas font-scale |
+| `paulgibeault/si-syn` | [si-syn.md](si-syn.md) | Cinematic timers run while hidden, locked-level rehydrate |
+| `paulgibeault/cozy-solitaire` | [cozy-solitaire.md](cozy-solitaire.md) | Idle clock freeze, standalone flush, dead code |
+| `paulgibeault/sowduku` | [sowduku.md](sowduku.md) | SW caches the SDK, no suspend handling, non-square art, dir/slug |
+
+## Two systemic themes (fix once in the framework)
+
+**A. Service workers.** Three games break the platform three ways (moon-lit
+nukes origin caches; hecknsic + sowduku cache the same-origin SDK). Root cause:
+the "a SW controls every fetch the page makes, not just fetches under its path"
+rule is undocumented as code. Framework fix in
+[framework-launcher.md](framework-launcher.md) §B1 (reference `game-sw.js`,
+copy-paste snippet in GAME_INTEGRATION.md §10, escalate `checkSWCollision`,
+`acceptance.mjs` offline check).
+
+**B. Lifecycle / suspend.** Five of seven games get suspend or resume subtly
+wrong. Root causes are framework-shaped: standalone never fires suspend/resume;
+`document.visibilityState` doesn't reflect iframe-pool hiding; no managed
+rAF/timer helper. Framework fix in [framework-launcher.md](framework-launcher.md)
+§B2–B4.
+
+## Priority (across all repos)
+
+1. p2p-chat stored XSS
+2. moon-lit origin-wide SW/cache nuke
+3. Launcher inbound `postMessage` origin check
+4. `__proto__` import-regex + `deepMerge` hardening
+5. Known Peers `loadP2P` scope bug (dead feature)
+6. SW SDK-caching in hecknsic + sowduku
+7. Rendezvous fingerprint-gated pair rebind
+8. Remove TEMP p2p-chat launcher button; square sowduku art

--- a/plans/cozy-solitaire.md
+++ b/plans/cozy-solitaire.md
@@ -1,0 +1,59 @@
+# Plan — Cozy Solitaire (`paulgibeault/cozy-solitaire`, gameId `cozy-solitaire`)
+
+Source: platform integration review. The closest thing the platform has to a
+reference integration — SDK-owned storage, three clean chained migrations,
+session-timer persistKey, dirty-rect rAF hygiene, reduced-motion + handedness.
+Both real findings expose framework gaps more than game bugs. Line numbers from
+the reviewed tree — re-confirm.
+
+## Bugs
+
+### 1. Idle clock freezes between interactions — MED
+- **Where:** the rAF loop is dirty-driven and only self-reschedules during
+  auto-complete/tweens/win/drag (`js/main.js:404-406`); `UI.updateHeader` runs only
+  inside `render()` (`:414`).
+- **Problem:** while the player sits thinking, the header time display freezes then
+  jumps on the next interaction (elapsed itself stays correct via `Arcade.session`).
+- **Fix:** a 1 Hz tick started/cleared in `onResume`/`onSuspend`, gated on
+  `updateTimerState`'s `shouldRun`, that calls `markDirty()` or updates the DOM clock.
+  (Framework B4's `t.onTick` would replace this once available.)
+
+### 2. Standalone never flushes elapsed on tab close — MED (framework-exposed)
+- **Where:** save-on-hide hangs off `Arcade.onSuspend` (`js/main.js:139-142`) +
+  the session timer's persistKey write, but suspend is only delivered when framed
+  (`arcade-sdk.js:747-751,799-803`). Game state is safe (saved every move), but
+  standalone loses accrued time since the last interaction boundary.
+- **Fix (interim):** add
+  `window.addEventListener('pagehide', () => { if (state)
+  saveGameState(serializeState(state)); Arcade.state.set('sessionElapsed',
+  _timer.elapsedMs()); })`.
+- **Real fix:** framework B2 (SDK fires suspend/resume standalone). Remove the
+  interim listener once B2 lands.
+
+## Cleanup
+
+### 3. Delete dead weight — LOW
+- `startTime` field still created/serialized/deserialized/reset
+  (`js/game.js:39,222,279`; `js/main.js:222`) though the v3 migration moved time to
+  `Arcade.session` — nothing reads it. Remove.
+- Delete `MIGRATION_session_persistKey.md` (work landed in `c9525b3`).
+- Fix the stray extra `</div>` at `index.html:119`.
+- Replace `js/main.js?v=4` manual cache-bust with a build/deploy hash convention.
+
+### 4. Document theme opt-out; small UX — LOW
+- Add the one-line §5 README note (single mandatory cabin-warm palette).
+- Adopt `Arcade.ui.toast` for "Best time!", "Seed applied", "No more passes"
+  (currently just a ✕ glyph, `js/main.js:432`).
+- Under `Arcade.settings.reducedMotion()`, complete the card-by-card auto-complete
+  (`js/main.js:361-384`) instantly.
+
+## Framework-feedback (surfaced here; see framework plan)
+- B2 standalone suspend/resume (fixes §2 for every game at once).
+- B4 `t.onTick` suspend-aware tick (fixes §1).
+- B5 ascending `Arcade.scores` order (a solitaire best-times board wants lower-is-
+  better) + keyed bests.
+- B9 `Arcade.state.adopt(legacyKey, newKey)` (cozy re-implements `takeRaw`/`takeJSON`
+  in its v1 migration, `index.html:22-33`).
+
+## Priority
+1 → 2 → 3 → 4.

--- a/plans/framework-launcher.md
+++ b/plans/framework-launcher.md
@@ -1,0 +1,246 @@
+# Plan — Framework & Launcher (`paulgibeault/paulgibeault.github.io`)
+
+Source: platform/security review of `arcade-sdk.js`, `arcade-p2p.js`, launcher
+`index.html`, `sw.js`, and `p2p/`. Findings are grouped into **Part A —
+security & correctness** (ship before next release) and **Part B — framework
+enhancements** (each fixes a bug that recurs across multiple games).
+
+Line numbers are from the reviewed tree; re-confirm before editing.
+
+---
+
+## Part A — Security & correctness (before next release)
+
+### A1. Inbound `postMessage` has no origin check — HIGH
+- **Where:** `index.html:1151-1156` (message handler gates only on `e.source`).
+- **Problem:** Both docs promise an origin allowlist (ARCADE_PLATFORM.md:288,
+  GAME_INTEGRATION.md:470) but the handler deliberately skips it "for local dev".
+  The sandbox does not stop an iframe from navigating *itself* cross-origin (a
+  stray `<a href>` suffices); afterward `e.source` still matches the pool entry,
+  so an arbitrary origin can drive `ls-proxy` read/write (replies posted to
+  `e.origin`), `arcade:peer.send`, and toasts.
+- **Fix:** Each pool entry already captures its origin at mount
+  (`index.html:899-902`). Add `if (e.origin !== entry.origin) return;`. For the
+  dev harness, allow `location.origin` (same-origin staging already matches).
+- **Accept:** cross-origin message from a mounted-but-navigated frame is ignored;
+  same-origin games unaffected; `npm run acceptance` still green.
+
+### A2. `__proto__` passes the import allowlist and reaches `deepMerge` — HIGH
+- **Where:** `KEY_RE` at `index.html:807`; SDK `deepMerge` at
+  `arcade-sdk.js:141-150` (reached via `state.getOrInit`/`stats.getOrInit`).
+- **Problem:** `KEY_RE` matches `arcade.v1.__proto__.x` and
+  `arcade.v1.global.__proto__`, contradicting ARCADE_PLATFORM.md:289. Keys are
+  inert in localStorage, but imported *values* are attacker JSON: `JSON.parse`
+  makes `__proto__` an own-enumerable key, `for (k in override)` iterates it, and
+  `out[k] = ov` fires the prototype setter — inherited-property injection on the
+  merged game-state object.
+- **Fix (two layers):**
+  1. Reject `__proto__`/`constructor`/`prototype` path segments in `KEY_RE`
+     (launcher import).
+  2. Harden `deepMerge`: iterate `Object.keys(override)`, `continue` on
+     `k === '__proto__' || k === 'constructor' || k === 'prototype'`, and/or
+     build `out` with `Object.create(null)`.
+- **Accept:** an import file with a `__proto__` segment is dropped with a warning;
+  a stored value containing `{"__proto__": {...}}` does not alter the merged
+  object's prototype. Add a unit/acceptance probe.
+
+### A3. Known Peers auto-reconnect toggle is dead code (ReferenceError) — HIGH (completeness)
+- **Where:** `index.html:664` (knownPeersController IIFE) calls `loadP2P()`,
+  declared in the *separate* platformController IIFE at `index.html:957`.
+- **Problem:** 🔁/🚫 throws `ReferenceError: loadP2P is not defined`; the toggle
+  documented at ARCADE_PLATFORM.md:193 silently does nothing.
+- **Fix:** Expose `loadP2P` on the shared object (e.g. `window.__arcade.loadP2P`,
+  matching `openMultiplayerPanel` at `index.html:1045`) and call that from the
+  Known Peers panel.
+- **Accept:** toggling auto-reconnect from the panel enables/disables pairing with
+  no console error.
+
+### A4. Rendezvous pair secret rebinds on a remote-claimed `deviceId` — MED
+- **Where:** `arcade-p2p.js:296-307`; `recordPeerIdentity` at
+  `arcade-p2p.js:171-193` (validates only `typeof === 'string'`).
+- **Problem:** `deviceId` is peer-chosen. A peer you ceremony with once can claim
+  another device's id and capture that pair's auto-reconnect slot; the
+  `fingerprintChanged` signal only raises a toast (`index.html:983-985`) and never
+  gates the rebind.
+- **Fix:** In the identity handler, refuse `rdv.enablePair(...)` when the direct
+  link's fingerprint mismatches the stored `knownPeers[deviceId].fingerprint`
+  (or require explicit user confirmation). Validate deviceId format (UUID-ish
+  pattern, bounded length) in `recordPeerIdentity`.
+- **Accept:** a mismatched-fingerprint identity does not silently rebind the pair
+  secret; malformed deviceIds are rejected.
+
+### A5. Launcher SW intercepts game URLs — MED (completeness/claim-drift)
+- **Where:** `sw.js:56-60` calls `respondWith(...)` for every root-scope fetch,
+  no path filter. GAME_INTEGRATION.md:365 says it doesn't intercept game URLs.
+- **Problem:** For games without their own SW, offline requests resolve
+  `caches.match → undefined`, producing an opaque TypeError instead of a normal
+  network error. Cache *contents* are correctly launcher-scoped, so this is
+  claim-drift, not poisoning.
+- **Fix:** Early-return unless the request path is in the launcher's own asset set
+  (root-level launcher files, `p2p/`, `images/`). Add `images/sowduku.png` and
+  `images/p2p-chat.png` to `ASSETS` (currently missing though on the grid).
+- **Accept:** requests for `/<gameId>/…` fall through to network; launcher assets
+  still served from cache offline.
+
+### A6. `#p2p-offer=` fragment auto-answers with no consent — LOW-MED (privacy)
+- **Where:** `p2p-ui.js:170-243` (runs `createAnswer` on load), broadcast at
+  `p2p-ui.js:249-276`.
+- **Problem:** Opening a crafted offer link immediately starts ICE/STUN toward the
+  link author's endpoints and auto-broadcasts the answer — enough to reveal the
+  victim's public IP. Undocumented.
+- **Fix:** One confirmation tap ("Accept this invite?") before `createAnswer`.
+- **Accept:** landing on an offer link shows a prompt; no ICE/answer until the user
+  accepts.
+
+### A7. Remove committed TEMP catalog entry — LOW
+- **Where:** `index.html:386-393` — p2p-chat button annotated "TEMP local-dev only
+  — remove before pushing".
+- **Problem:** 404s in prod and inflates `gameCount`, loosening the pool-cap clamp
+  (`index.html:522`). NOTE: p2p-chat also needs the `#games` mirror in
+  `profile.html` — coordinate with the p2p-chat plan; if p2p-chat is a real
+  release, finish the catalog entry instead of removing it.
+- **Fix:** Either remove the button+card or promote to a real release (image,
+  profile.html `#games` mirror per §11).
+- **Accept:** no dead launcher button in prod; `gameCount` reflects shipped games.
+
+### A8. Broker-trust doc line is overstated — LOW (docs)
+- **Where:** ARCADE_PLATFORM.md:194 ("the broker can only delay or drop").
+- **Problem:** Crypto holds (AEAD w/ direction+epoch AAD, HKDF from sorted
+  randoms, exchange-gated ratchet, non-extractable keys) — but any wildcard
+  subscriber on `qrp2p/r/v1/#` learns both IPs, that the pair rendezvous, and
+  timing. Garbage blobs also cost the listener up to 3 AES-GCM attempts
+  (`rendezvous.js:424-428`), a DoS-only nuisance.
+- **Fix:** One honest sentence about metadata leakage in the doc; optionally
+  rate-limit blob processing.
+
+### A9. Latent CDN URLs + stale UI version label — LOW (defense-in-depth)
+- **Where:** `p2p-addon.js:52-53` (cdnjs URLs, only avoided via load order in
+  `arcade-p2p.js:258-259`); `p2p-ui.js:461` hardcodes "v1.6.1" while docs describe
+  transport v1.9 (and the UI tells users to compare that header across devices).
+- **Fix:** Point the addon at `./vendor/`; update the modal version label (or read
+  it from a single constant).
+
+---
+
+## Part B — Framework enhancements (each fixes a fleet-wide recurrence)
+
+### B1. Service-worker hygiene toolkit — from moon-lit / hecknsic / sowduku
+- Ship a reference `game-sw.js` template: scope-filtered fetch handler
+  (`if (!url.pathname.startsWith(SCOPE)) return;`) + version-keyed cache.
+- Add the copy-paste fetch-guard snippet to GAME_INTEGRATION.md §10 (currently
+  says "never cache" with no code).
+- Escalate the SDK's `checkSWCollision` (`arcade-sdk.js:380-394`) from
+  `console.warn` to a visible dev-mode error, and probe whether *any* launcher-root
+  asset was served by a game SW (not just the SDK's own script entry).
+- Add an offline-reload check to `tools/acceptance.mjs` (§13 currently only tests
+  that the SW doesn't cache launcher assets, not that games cache their own).
+- Document the origin-wide-cleanup foot-gun: "never call `caches.delete` /
+  `getRegistrations().unregister` outside your own scope" (moon-lit shipped exactly
+  this).
+
+### B2. Standalone suspend/resume — from cozy-solitaire / sowduku
+- **Problem:** the SDK fires `onSuspend`/`onResume` only when framed, so every game
+  that (correctly) moved flush/pause logic into `onSuspend` silently regresses
+  standalone, and `session.start({persistKey})` never persists standalone.
+- **Fix:** when `!framed`, the SDK listens to `visibilitychange`/`pagehide` and
+  fires the same `listeners.suspend`/`listeners.resume` arrays. Zero game changes;
+  fixes cozy, sowduku, and every future game at once.
+
+### B3. Expose suspend state to games/CSS — from sowduku
+- **Problem:** `document.visibilityState` stays `"visible"` for a hidden iframe, so
+  polling-style time trackers keep accruing (sowduku's `playMs` inflates).
+- **Fix:** SDK sets `Arcade.context.suspended` (readable getter) and toggles
+  `data-arcade-suspended` on `<html>` so code mounted mid-session (and CSS) can
+  read current state without having subscribed from t=0.
+
+### B4. Managed rAF loop + suspend-aware scheduling — from pi-game / si-syn / cozy / hecknsic
+- **Problem:** every canvas game re-implements "cancel rAF on suspend, re-request
+  on resume" and someone always gets it wrong (pi-game freezes on resume;
+  si-syn's cinematics keep ticking hidden; cozy's clock freezes; hecknsic spins
+  rAF while paused).
+- **Fix:**
+  - `Arcade.loop(fn)` → `{ start(), stop(), kick() }` that auto-cancels on suspend,
+    auto-resumes only if it was running, and feeds a suspended-time-excised delta.
+  - `Arcade.session.setTimeout(fn, ms)` / `.setInterval(fn, ms)` (or `t.onTick(fn,
+    intervalMs)`) that auto-freeze on suspend, resume with remaining time, and
+    cancel on `stateReplaced`.
+
+### B5. `Arcade.scores` sort order + keyed bests — from cozy / sowduku / si-syn
+- **Problem:** `scores.add` sorts descending only (`arcade-sdk.js:635`), locking out
+  time-based "lower is better" games; sowduku wants best-per-board-code, not top-N.
+- **Fix:** `scores.add(cat, entry, { order: 'asc' })` (or `scores.configure(cat,
+  {order})`), and a keyed-best variant `scores.best(category, key)` — or document
+  `Arcade.stats` as the blessed home for keyed maps.
+
+### B6. Peer identity + presence surface — from p2p-chat
+- **Problem:** p2p-chat had to invent its own persistent `myId` and a retry+echo
+  hello handshake because `fromPeer` is the hardcoded string `'peer'`
+  (`index.html:1027`) and no stable peer identity is exposed — even though the
+  launcher already keys auto-reconnect on `deviceId`.
+- **Fix:** expose `Arcade.peer.self()` / `Arcade.peer.remote()` (or a roster),
+  stamp `fromPeer` with the real id, and emit a "remote game with matching gameId
+  is now listening" presence/ready event so games stop re-solving handshake-with-
+  backoff.
+
+### B7. Binary/large-payload helper + queue visibility — from p2p-chat
+- **Problem:** p2p-chat owns 60+ lines of base64 chunking/reassembly/progress; the
+  1000-message replay cap is invisible to games (chained file sends during one
+  `interrupted` episode can silently overrun it).
+- **Fix:** `Arcade.peer.sendBlob(blob, {onProgress})` / `onBlob`, and expose queue
+  depth or a "queue full / dropping" event.
+
+### B8. `data-reduced-motion` DOM hook + kill-switch rule — from si-syn / p2p-chat / sowduku
+- **Problem:** the SDK sets `--motion-scale` (needs every duration rewritten as
+  `calc()`), so games hand-roll blanket approaches and p2p-chat's broke on a
+  `--motion` vs `--motion-scale` name mismatch.
+- **Fix:** also set `data-reduced-motion="true|false"` on `<html>` and ship the
+  standard `[data-reduced-motion="true"] * { animation-duration:.001ms!important;
+  transition-duration:.001ms!important; }` rule in the injected base style
+  (opt-out-able like the font-size rule).
+
+### B9. Migration ergonomics — from cozy / hecknsic
+- **Fix:** `Arcade.state.adopt(legacyKey, newKey, { json = true })` (read →
+  namespaced write → delete original, error-safe) so migrations shrink to a line.
+- Doc note in §3: "treat `onStateReplaced` like a fresh boot — recompute your start
+  screen from storage; don't assume the current screen is valid in the imported
+  save" (si-syn's locked-level bug), plus an intra-namespace schema-bump example.
+
+### B10. `dev.sh` should read gameId from the game, not the dir basename — from sowduku
+- **Where:** `dev.sh:133,176` (`game_id="$(basename "$game_dir")"`).
+- **Problem:** a checkout named differently from the slug (`sow-duku` vs `sowduku`)
+  makes launcher buttons and `acceptance.mjs` 404.
+- **Fix:** grep the staged `index.html` for `Arcade.init({ gameId: ... })`, or
+  accept a `../dir:gameId` override, and mount at `/<gameId>/`.
+
+### B11. Retire the ls-proxy legacy path — from hecknsic
+- The only game that shipped the shim (hecknsic) removed it. Sequence: land
+  hecknsic's `.ls.*` data-recovery migration (see hecknsic plan), wait one release,
+  then delete `handleLsProxyRequest` and the `ls-proxy-request` branch
+  (`index.html:1099-1163`) and the back-compat notes in GAME_INTEGRATION.md §9.
+
+### B12. Save-export governance + import semantics — from moon-lit
+- **Problem:** nothing caps per-game export weight (moon-lit ships 500-record
+  telemetry into every save); import is merge-not-replace while the UI says
+  "replace N keys" (`index.html:1461-1471`); OS theme flips mid-session don't
+  re-broadcast (no `matchMedia` change listener at `index.html:1219-1252`).
+- **Fix:** optional `Arcade.state.set(key, v, { exportable:false })`; make the
+  confirm copy match merge behavior (or offer replace); add `matchMedia` listeners
+  that fire `arcade:settings.changed`.
+
+### B13. Structural: de-god the platformController — MED (cohesion)
+- **Where:** `index.html:803-1486` — one ~680-line IIFE coordinating with five
+  siblings via 12+ `window.__arcade.*` properties. Finding A3 is a direct symptom.
+- **Fix:** extract save/load and p2p wiring into ES modules (arcade-p2p.js proves
+  the pattern); make `window.__arcade` a single explicitly-constructed object;
+  give `knownPeers` a single owner (the bridge) exposing rename/delete to end the
+  duplicated CRUD + last-write-wins race (`index.html:576-595` vs
+  `arcade-p2p.js:142-152`).
+
+---
+
+## Suggested sequencing
+1. A1–A3 (small, localized, high-value) → A4, A5.
+2. B2–B4 + B1 (the systemic lifecycle + SW fixes that unblock game plans).
+3. B5–B9, B12 (SDK API additions; coordinate with game plans that depend on them).
+4. B10, A6–A9, B13 (tooling, hardening, refactor when convenient).
+5. B11 after hecknsic's migration ships and one release passes.

--- a/plans/hecknsic.md
+++ b/plans/hecknsic.md
@@ -1,0 +1,63 @@
+# Plan — HecknSic (`paulgibeault/hecknsic`, gameId `hecknsic`)
+
+Source: platform integration review. One of the better-migrated games — the old
+ls-proxy shim is fully removed; storage, scores, player name, handedness,
+suspend/resume, and legacy migration all go through the SDK. Two real problems: a
+service worker that caches launcher assets, and orphaned shim-era data. Line
+numbers from the reviewed tree — re-confirm.
+
+## Bugs
+
+### 1. Service worker caches `/arcade-sdk.js` (and everything) — HIGH
+- **Where:** `sw.js:54-74` runs cache-first for *every* GET the page makes, no URL
+  scoping (the localhost skip at `:56` only helps dev).
+- **Problem:** in prod the iframe's SDK request (`index.html:15`) is cached under
+  `hecknsic-v1.3.0`, so a stale SDK is served indefinitely and the SDK's
+  `checkSWCollision` warning fires. Violates GAME_INTEGRATION.md §10/§13.
+- **Fix:** in the fetch handler, bail unless
+  `new URL(event.request.url).pathname.startsWith('/hecknsic/')` (or matches
+  `self.registration.scope`). Bump `CACHE_VERSION` to purge cached SDKs on deployed
+  clients. (Aligns with framework B1 template.)
+- **Accept:** SDK request falls through to network; no `[Arcade SDK]` warning.
+
+### 2. Shim-era `.ls.*` data orphaned by migration — MED
+- **Where:** framed-era play was stored under `arcade.v1.hecknsic.ls.<rawKey>`
+  (launcher `index.html:1104-1105`), but `migrate('v1')` reads only the plain
+  `hecknsic_*` keys (`index.html:24-27`).
+- **Problem:** a user who played framed during v1.2.13 silently lost
+  settings/progress on upgrade, and the `.ls.` keys ride every save as dead weight.
+- **Fix:** add `Arcade.state.migrate('v2', …)` that enumerates
+  `arcade.v1.hecknsic.ls.*`, re-runs the v1 mapping on the embedded raw keys, and
+  deletes the originals. **This is the prerequisite for retiring the launcher's
+  ls-proxy path (framework B11).**
+
+### 3. rAF not cancelled on suspend — LOW (§6c)
+- **Where:** `gameLoop` early-returns but re-requests rAF every frame while paused
+  (`js/main.js:584-587`).
+- **Fix:** store the rAF id, `cancelAnimationFrame` in `onSuspend`, re-request in
+  `onResume` (already resets `lastTime`). Or adopt framework B4's `Arcade.loop`.
+
+### 4. Canvas text ignores fontScale — LOW (§5)
+- **Where:** score popups / bomb timers / labels use fixed px
+  (`js/renderer.js:849,1070,1165`); the 10px handedness pill (`css/style.css:110`).
+- **Fix:** cache `Arcade.settings.fontScale()`, multiply the three `ctx.font` sites,
+  redraw from the existing `onSettingsChange` subscription.
+
+## Cleanup
+- Gate canvas tweens on `reducedMotion` (the follow-up comment at `js/main.js:207`
+  already promises this) — scale `js/tween.js` durations by
+  `reducedMotion() ? 0 : 1`.
+- Switch the SDK `<script src>` to root-relative `/arcade-sdk.js` (`index.html:15`).
+- Delete vestigial `DEFAULT_SETTINGS.theme`/`soundVolume` (`js/storage.js:12-14`) —
+  never read, no audio exists.
+- Replace the hand-rolled `showEditorStatus()` fade (`js/puzzle-editor.js:217-223`)
+  with `Arcade.ui.toast`; adopt `Arcade.stats` (games played/won, best combo).
+- Document the dark-only theme opt-out in README (§5).
+
+## Positive pattern to keep
+- The handedness integration (global-key single source of truth + hiding in-game
+  controls when framed, `js/main.js:178-205`) is exemplary — proposed as the §5
+  handedness reference example in the framework docs.
+
+## Priority
+1 → 2 → 3 → 4 → cleanup.

--- a/plans/moon-lit.md
+++ b/plans/moon-lit.md
@@ -1,0 +1,72 @@
+# Plan — Moon Lit (`paulgibeault/moon-lit`, gameId `moon-lit`)
+
+Source: platform integration review. Moon Lit is a strong integration (SDK-first
+storage, real suspend/resume, sleep-when-quiescent rAF, persisted session timer,
+scores/stats/toasts via the SDK), with one production-severity issue and two
+lifecycle/accounting bugs. Line numbers from the reviewed tree — re-confirm.
+
+## Critical
+
+### 1. Origin-wide SW/cache wipe destroys the launcher's service worker — HIGH
+- **Where:** `index.html:16-28` — unregisters *every* SW registration and deletes
+  *every* Cache Storage entry for the whole origin, on every load, in production.
+- **Problem:** `getRegistrations()`/`caches` in an `allow-same-origin` iframe are
+  origin-scoped, so launching Moon Lit silently unregisters the launcher's `/sw.js`
+  and deletes `paul-arcade-v19`, killing launcher offline support and sibling
+  caches. Violates GAME_INTEGRATION.md §10.
+- **Fix:** gate to loopback:
+  `if (['localhost','127.0.0.1','::1'].includes(location.hostname) ||
+  location.hostname.startsWith('127.'))` — or delete the block entirely (the
+  launcher SW already skips loopback and never intercepts game URLs).
+- **Accept:** launching Moon Lit in prod leaves the launcher SW + caches intact.
+
+## Bugs
+
+### 2. Suspend containment — browser events resurrect a launcher-suspended game — MED
+- **Where:** `onSuspend` sets `suspended=true` (`js/main.js:703-707`), but
+  `visibilitychange:visible` (`:721-729`), `pageshow` (`:731-734`), and `focus`
+  (`:736-739`) unconditionally clear it and call `forceRequestFrame()`.
+- **Problem:** launcher hides Moon Lit → user tab-switches and back → the hidden
+  iframe's rAF loop runs again.
+- **Fix:** two flags — `launcherSuspended` (only `onSuspend`/`onResume` touch it)
+  and `docHidden`; run the loop only when both are false. Browser handlers may
+  flush and wake only when `!launcherSuspended`.
+
+### 3. Save-import stats-delta accounting — MED
+- **Where:** `onStateReplaced` handler (`js/main.js:743-753`) does not reset
+  `lastReportedMs` (`:167`); the SDK timer re-baselines from imported
+  `sessionElapsed`.
+- **Problem:** next `recordOutcome` computes `playDelta = elapsedMs() -
+  lastReportedMs` against a stale baseline → undercount or large spurious
+  `totalPlayMs` inflation.
+- **Fix:** `lastReportedMs = sessionTimer.elapsedMs()` inside the
+  `onStateReplaced` handler.
+
+## Cleanup
+
+### 4. Finish the migration; stop dual-writing snapshots — LOW
+- Inline migrations (`js/main.js:102-126`) never delete superseded keys, and
+  `saveGameState` dual-writes to both `gameState_<mode>` and legacy `gameState`
+  forever (`:76-77`), doubling snapshot bytes in storage and every export.
+- **Fix:** move shape migrations into `Arcade.state.migrate('v2', ...)` (currently
+  an empty stub at `:99`), delete legacy keys, drop the legacy dual-write.
+
+### 5. Namespace admin-panel state; drop parallel best-score bookkeeping — LOW
+- `admin-group-collapsed-*` raw keys (`js/admin-panel.js:451-527`) collide across
+  games on the shared origin → `Arcade.state.set('adminCollapsed', {...})`.
+- Three sources of truth for best score (`bestScore` key, `stats.campaign.bestScore`,
+  `Arcade.scores.best('campaign')`) → drop `BEST_KEY`, keep a one-shot migrate.
+- Cap telemetry export weight (`telemetryLog` ships 500 records into every save;
+  100–200 is enough).
+
+### 6. Live player-name refresh — LOW
+- Subscribe `Arcade.player.onChange` so the win-card name updates when the launcher
+  profile changes (currently only boot + stateReplaced).
+
+## Depends on framework
+- §1's clean fix is aided by framework B1 (SW hygiene / "don't touch caches outside
+  your scope"); §2/§3 motivate framework B2 (unified suspend) and a `takeDelta()`
+  session helper — but all game-side fixes above stand alone.
+
+## Priority
+1 (critical) → 2 → 3 → 4 → 5 → 6.

--- a/plans/p2p-chat.md
+++ b/plans/p2p-chat.md
@@ -1,0 +1,72 @@
+# Plan — P2P Chat (`paulgibeault/p2p-chat`, gameId `p2p-chat`)
+
+Source: platform integration review. p2p-chat is the flagship `Arcade.peer.*`
+consumer and its multiplayer handling is exemplary (spec-correct `interrupted`
+handling, hello protocol, standalone degrade). It also carries the most serious
+security bug in the fleet. Line numbers from the reviewed tree — re-confirm.
+Default branch is `master`.
+
+## Critical
+
+### 1. Stored XSS via unescaped peer-controlled `id` fields — HIGH
+- **Where:** text/names are escaped via `escapeHtml` (`app.js:16-20`), but *ids*
+  interpolated into HTML attributes are not, and three come off the wire:
+  - hello: `incomingId` (`app.js:448`) → `data-peer-id="…"` (`app.js:291`)
+  - text: `id: payload.id || uid()` (`app.js:475`) → `data-id="…"` (`app.js:223,227`)
+  - files: `payload.id` (`app.js:489`) → `data-file-id`/`data-remove` (`app.js:195,267`)
+    and a `querySelector` selector-injection (`app.js:245`)
+- **Problem:** a peer sending `id: '"><img src=x onerror=…>'` gets script execution
+  in the same-origin iframe → read/write **all** `arcade.v1.*` storage for every
+  game and the launcher. Stored: histories persist (`app.js:153-172`) and re-render.
+- **Fix:** escape every peer-supplied id at each interpolation site, or validate on
+  receipt against `/^[\w-]+$/`. Also escape `name` fed to `openMedia`'s `alt="…"`
+  (`app.js:630`).
+- **Accept:** a peer message with markup in `id`/`name` renders inertly; no attribute
+  breakout; `querySelector` never throws on hostile ids.
+
+## Bugs / spec gaps
+
+### 2. File-send loop keeps sending during `interrupted` → replay-cap overrun — MED
+- **Where:** chunk loop (`app.js:591-595`); replay queue caps at 1000
+  (GAME_INTEGRATION.md:321). Two chained max-size files (`app.js:694`) ≈ 1168
+  messages → silent loss with sender believing `state:'done'`.
+- **Fix:** pause `sendChunk` while `currentStatus === 'interrupted'`, resume on
+  `'connected'` (or refuse to start a new file send while interrupted).
+
+### 3. Reduced-motion broken by a CSS variable-name mismatch — MED
+- **Where:** styles define `--motion:1` and divide by `var(--motion,1)`
+  (`styles.css:19,82-83,171,266`), but the SDK sets `--motion-scale`
+  (`arcade-sdk.js:233`) with multiply-by-0 semantics.
+- **Fix:** consume `--motion-scale` correctly (multiply, not divide — dividing by 0
+  breaks), or gate on the forthcoming `data-reduced-motion` hook (framework B8).
+
+### 4. Player-name changes don't propagate — LOW
+- `myName` read once (`app.js:752`), no `Arcade.player.onChange`. Renaming mid-session
+  leaves the peer seeing the old name. **Fix:** subscribe and re-hello.
+
+### 5. Missing migration sentinel — LOW
+- No `Arcade.state.migrate('v1', …)`, so the acceptance sentinel never exists
+  (GAME_INTEGRATION.md:430). No legacy keys exist, so a no-op `migrate('v1',
+  function(){})` in `init()` satisfies the check honestly.
+
+### 6. Bound `payload.chunks` allocation — LOW
+- `new Array(payload.chunks)` (`app.js:485`) trusts a peer-supplied count; clamp it.
+
+## Launcher-side coordination
+### 7. Finish or remove the catalog entry
+- p2p-chat is in `#view-launcher` (launcher `index.html:387`, marked TEMP) and has
+  `images/p2p-chat.png`, but is **absent from `#games` in profile.html**
+  (GAME_INTEGRATION.md:375). Decide: promote to a real release (add the profile
+  mirror, drop the TEMP note) or remove the launcher button. Tracked also in the
+  framework plan A7.
+
+## Framework-feedback (surfaced by this app; see framework plan)
+- B6 peer identity/roster + presence-ready event (kills the hand-rolled `myId` +
+  retry/echo hello dance, `app.js:434-463`).
+- B7 `Arcade.peer.sendBlob`/`onBlob` + replay-queue depth visibility (removes the
+  60+ lines of base64 chunking and makes §2 observable).
+- Delivery/ack surface so the app can show real delivery vs merely-queued
+  (`app.js:546-548` currently fabricates this from `send()`'s boolean).
+
+## Priority
+1 (critical) → 2 → 3 → 7 → 4 → 5 → 6.

--- a/plans/pi-game.md
+++ b/plans/pi-game.md
@@ -1,0 +1,67 @@
+# Plan — Pi Game (`paulgibeault/pi-game`, gameId `pi-game`)
+
+Source: platform integration review. Solid storage/migration/scores, but two
+lifecycle bugs and a broken offline claim. Line numbers from the reviewed tree —
+re-confirm.
+
+## Bugs
+
+### 1. Resume never restarts the rAF loop — HIGH (user-visible freeze)
+- **Where:** `onSuspend` cancels the loop (`index.html:1513`) but `onResume`
+  (`:1515-1518`) never calls `ensureAnimationLoop()` (`:1110-1112`).
+- **Problem:** active scenes (e.g. `OrbitalVisual.update()` returns true whenever
+  bodies exist, `visuals/orbital.js:120-121`) sit frozen after suspend/resume until
+  the user types a digit.
+- **Fix:** call `ensureAnimationLoop()` inside `Arcade.onResume`. One line.
+
+### 2. Hand-rolled timer accrues while hidden/evicted — HIGH
+- **Where:** `state.startTime = Date.now()` epoch + display `setInterval`
+  (`index.html:1243-1249,1273`); `onSuspend` stops only the display interval.
+- **Problem:** hidden time inflates run time; after eviction/reload or import the
+  inflated elapsed carries over.
+- **Fix:** adopt `Arcade.session.start({ persistKey: 'elapsedMs' })` — reset in
+  `startGame()`, read `t.elapsedMs()` for display and score meta. (Directly
+  motivates framework B4.)
+
+### 3. Reduced motion only partially honored — MED
+- Particles/shake are gated (`index.html:1115,1121,1282,1296`), but continuous
+  canvas visuals (`visuals/*.js update()`) and CSS ambient animations
+  (`neural-scanline` `:424-436`, `orbital-twinkle` `:438`, etc.) ignore it.
+- **Fix:** early-return/damp `update()` under `Arcade.settings.reducedMotion()`;
+  scale CSS keyframes by `calc(Ns * var(--motion-scale,1))`.
+
+### 4. Service worker can't deliver "works offline" — MED
+- **Where:** `sw.js:5-10` caches only `./`, `index.html`, `manifest.json`, `icon.svg`
+  — not `visuals/*.js`; the non-navigate fetch handler never cache-puts
+  (`sw.js:43-45`).
+- **Fix:** add `visuals/*.js` (versioned) to `ASSETS` or cache-put successful
+  fetches; bump `CACHE_NAME`. (Aligns with framework B1 SW template.)
+
+## Cleanup
+
+### 5. Stop persisting the 1000-digit `piSequence` in the state blob — LOW
+- `DEFAULT_STATE` (`index.html:986-987`) rides every keypress save + every export,
+  then is overwritten on load (`:1131`). Slim state to
+  `{gameState, currentTheme, userSequence, soundEnabled, cameraFollow}` (+ elapsed).
+
+### 6. Drop the runtime blob-URL manifest hack — LOW
+- `index.html:962-977` replaces the static `manifest.json` with a `Blob` manifest;
+  `start_url`/`scope` resolution against a `blob:` URL is unreliable. Keep the
+  static manifest, ship real PNG icons.
+
+### 7. Stale vendored SDK on disk — LOW
+- The repo-root `arcade-sdk.js` mirrored by `go.sh:12-20` predates `Arcade.session`,
+  `stats.getOrInit`, and current peer-send semantics — local dev can misrepresent
+  SDK behavior. Prefer the launcher's `dev.sh` (framework B10); re-copy via `go.sh`
+  before testing.
+
+## Enhancements (optional)
+- Show `e.name` on the leaderboard (entries already carry it via `Arcade.player`);
+  offer a small name prompt writing `Arcade.player.setName`.
+- Add `Arcade.stats` (`gamesPlayed`, `totalDigits`, `bestScore`) and
+  `Arcade.ui.toast('New personal best!', {kind:'success'})`.
+- Map launcher `theme()` to a default aesthetic on first run, or add the one-line
+  README opt-out note (§5).
+
+## Priority
+1 → 2 → 3 → 4 → 5 → 6 → 7 → enhancements.

--- a/plans/si-syn.md
+++ b/plans/si-syn.md
@@ -1,0 +1,57 @@
+# Plan — Si Syndicate (`paulgibeault/si-syn`, gameId `si-syn`)
+
+Source: platform integration review. A clean integration (proper namespacing, v1
+migration, suspend/resume, fontScale + reducedMotion). Main gap: JS timer chains
+keep firing while the game is hidden. Line numbers from the reviewed tree —
+re-confirm.
+
+## Bugs
+
+### 1. `setTimeout`/interval chains run while hidden — MED (§6c)
+- **Where:** `onSuspend` stops the sim rAF (`src/main.js:919-929`), but timer chains
+  ignore suspension: boot cinematic (`src/ui/boot.js:141-164,209-227`), guide steps
+  (`src/ui/guide.js:144`), 100 ms tray-placement poll (`src/main.js:348-357`),
+  auto-advance timeouts (`src/main.js:883,888`).
+- **Problem:** a user who launches for the first time and immediately switches to the
+  launcher misses the cinematic; battery/CPU burn on hidden iframe.
+- **Fix:** on `Arcade.onSuspend`, clear the boot/guide timeout ids and the tray
+  poll; on resume, reschedule the remainder (or `skip()` to finished state on
+  suspend). Simplest: adopt framework B4's suspend-aware `Arcade.session.setTimeout`
+  once available. Replace the tray poll with an `onPlacingEnd` callback from
+  `circuit-board.js`.
+
+### 2. `onStateReplaced` can restore into a now-locked level — LOW
+- **Where:** `src/main.js:930-934` reloads `currentLevel.id` even if the imported
+  save has that level locked.
+- **Fix:** after import, if `!isLevelUnlocked(currentLevel.id)`, fall back to the
+  computed start level (`src/main.js:949-952`). Treat `onStateReplaced` like a fresh
+  boot (framework B9 doc note).
+
+## Cleanup
+
+### 3. Gate cinematics on reducedMotion — LOW
+- Boot/guide typewriter animations aren't gated (only tap-to-skip). Under
+  `Arcade.settings.reducedMotion()`, call the existing `renderAllLines()` path
+  (`src/ui/boot.js:82-90`) to finish instantly.
+
+### 4. Remove stale integration-era artifacts — LOW
+- `ago` (own dev harness), `ARCADE_LAUNCHER_NOTES.md` (all asks shipped in the
+  launcher: dev.sh, `?dev=1`, acceptance, SW loopback skip), and the
+  gitignored `.arcade-stage/` copy of `arcade-sdk.js` are now misleading. Delete;
+  use the launcher's `dev.sh` + `npm run acceptance`.
+
+### 5. Switch SDK `<script src>` to root-relative — LOW
+- `index.html:19` uses the absolute URL; §2 prescribes `/arcade-sdk.js`.
+
+### 6. Document theme opt-out — LOW
+- Fixed dark-terminal aesthetic; add the one-line §5 note to `README.md`.
+
+## Enhancements (optional, high value for this game type)
+- This is a Zachtronics-style optimizer — adopt `Arcade.stats.update(levelId, …)`
+  (cycles-to-pass, instruction count, attempts) and `Arcade.scores.add(levelId,
+  {score: -cycles, meta:{instructions}})` for a "best solution" UI. (Needs framework
+  B5 ascending order, or keep negating scores.)
+- Use `Arcade.ui.toast` for "Program cleared" / "Progress restored".
+
+## Priority
+1 → 2 → 3 → 4 → 5 → 6 → enhancements.

--- a/plans/sowduku.md
+++ b/plans/sowduku.md
@@ -1,0 +1,70 @@
+# Plan — Sowdoku (`paulgibeault/sowduku`, gameId `sowduku`)
+
+Source: platform integration review. Newly added to the catalog
+(`add-sowduku-catalog` / PR #14). gameId, repo slug, launcher URL, and image name
+all agree on `sowduku` — but integration is incomplete: the service worker caches
+the SDK, nothing pauses when hidden, and launcher art isn't square. Line numbers
+from the reviewed tree — re-confirm. NOTE: the local checkout dir is `sow-duku`;
+the GitHub repo/slug is `sowduku`.
+
+## Bugs
+
+### 1. Service worker caches `/arcade-sdk.js` — HIGH
+- **Where:** `sw.js:52` bypasses only *cross-origin* requests, but the SDK is loaded
+  root-relative same-origin (`index.html:25`); the cache-first branch
+  (`sw.js:55-63`) caches `/arcade-sdk.js` and serves it stale forever.
+- **Problem:** freezes the platform SDK for every installed user; second load fires
+  the SDK's `[Arcade SDK]` warning. Violates GAME_INTEGRATION.md §10/§13.
+- **Fix:** `if (url.pathname === '/arcade-sdk.js' ||
+  !url.pathname.startsWith('/sowduku/')) return;` (the scope-prefix form also
+  future-proofs and stays correct in the dev harness). Bump `CACHE` to purge
+  poisoned installs. (Aligns with framework B1.)
+
+### 2. No suspend handling → `playMs` inflates while hidden — HIGH
+- **Where:** no `onSuspend`/`onResume` anywhere; the 1 Hz `setInterval`
+  (`index.html:1654`) runs forever, and `flushTick` gates on
+  `document.visibilityState === 'visible'` (`:1650`) — which stays `'visible'` when
+  the launcher merely hides the iframe.
+- **Problem:** play-time keeps accruing in the launcher or another game, corrupting
+  the history metrics the game features.
+- **Fix:** on `onSuspend` — `flushTick()`, set a `suspended` flag checked in
+  `flushTick`, `persist()`, `audioCtx.suspend()`, clear the interval; on `onResume`
+  — `lastTick = Date.now()`, restart. Or delete the tick machinery and use
+  `Arcade.session.start({ persistKey })`, reading `elapsedMs()` into `metrics.playMs`.
+  (Motivates framework B2/B3.)
+
+### 3. Launcher art is not square — MED (§11)
+- `images/sowduku.png` is 1023×746; §11 requires square ≥512×512. Reconcile the
+  unmerged `add-sowduku-catalog` logo commits (`1bfe692`, `527dd74`) and ship a
+  square image (launcher-repo PR).
+
+### 4. Local checkout dir vs slug breaks dev/acceptance — MED
+- `dev.sh` mounts by directory basename, so `./dev.sh ../sow-duku` stages at
+  `/sow-duku/` while the launcher button points at `/sowduku/` → local launch 404s
+  and `acceptance.mjs` can't run against the documented URL.
+- **Fix (game side):** rename the local checkout `sow-duku` → `sowduku`, then run
+  `./dev.sh ../sowduku` + `npm run acceptance -- http://127.0.0.1:4791/sowduku/`.
+  (Framework B10 fixes this at the harness level.)
+
+## Cleanup
+
+### 5. Delete the storage fallback shim; use `Arcade.state` directly — LOW
+- `sget`/`sset` (`index.html:756-768`) duplicate the `arcade.v1.sowduku.` prefix as a
+  string for a `file://` case §2 declares unsupported. Two sources of truth + divergent
+  parse behavior. Remove; the SDK guarantees standalone operation.
+
+### 6. Migrate hand-rolled stats to `Arcade.stats` — LOW
+- `stats` blob (`index.html:1472,1616`) maps 1:1 onto `Arcade.stats.getOrInit/update`.
+  (The keyed `hiScores`-by-board-code store is a fair reason to wait for framework B5.)
+
+### 7. Honor reducedMotion + audioVolume; add sentinel; misc — LOW
+- CSS animations disabled only via `@media (prefers-reduced-motion)` (`index.html:456`);
+  also key off the SDK's motion hook (framework B8) or `Arcade.settings.reducedMotion()`.
+- Multiply WebAudio gain peaks by `Arcade.settings.audioVolume()` (`:975-1007`).
+- Add a no-op `Arcade.state.migrate('v1', () => {})` if acceptance checks the sentinel.
+- Document the fixed light-palette theme opt-out in README (§5).
+- Subscribe `onSuspend` to `audioCtx.suspend()`.
+- Trim the Pages artifact (exclude `PLAN.md`, mockups, `scripts/`).
+
+## Priority
+1 → 2 → 3 → 4 → 5 → 6 → 7.


### PR DESCRIPTION
## What & why

Two **ship-blocker** findings from the hardened security review of the multiplayer-protocol rework. Both are small, surgical fixes chosen deliberately to **not** refactor anything — we want to test the current architecture before the larger standardization work (Noise, `mqtt.js`, SDP-codec demotion) tracked in the security-hardening issue.

Base is `issue-17-platform-fixes` so the diff is exactly these two fixes, reviewable in isolation from the rework in #19.

### 1. Peer impersonation through the host relay — `p2p/p2p-core.js`
In a 3+ peer session the host relayed app messages using the **sender-supplied `from`** verbatim:
```js
this._sendAppTo(destId, { text: msg.text, from: msg.from, relayed: true });
```
A joiner could send `{ text, from: "<victimId>" }` and the host fanned it out to everyone as authored by the victim. The code comment even said identity "must never bind through a relay," but nothing enforced it.

**Fix:** stamp `from` with the source link's host-assigned `peerId` — the key the inbound data channel is registered under, which a client cannot forge. The old `msg.from !== this.myId` guard was forgeable and unnecessary (inbound frames are always from a remote client, never the host), so it's removed.

> Note: the arcade bridge already attributes identity by the unforgeable `d.peerId`, so the arcade layer was not exploitable — but the transport is a general-purpose library and the relayed `from` lied to any consumer. Fixed at the source.

### 2. Auto-reconnect key ratchet bricks pairs — `p2p/rendezvous.js`
Each side advanced the pair base key (`rec.base`) on a sealed reconnect from a purely **local** condition, with no agreement step. Any divergence — one side heals in-band while the other adopts the sealed connection, or DTLS fingerprints populate a tick later on one end — split the base key. Because **both the AEAD key and the daily rendezvous topic derive from `base`**, a split makes the pair permanently deaf in both directions (the epoch window can't rescue a wrong key on a wrong topic). Net effect: auto-heal could **brick a pairing** until a manual Start Over + fresh invite on *both* devices. The old code logged this desync as a warning rather than preventing it.

**Fix:** freeze the pair secret across unattended reconnects. Both sides always hold the key minted over DTLS at the last **manual** ceremony (`_establishPair` re-derives base + resets epoch 0 on both ends simultaneously — symmetric by construction), and it never changes underneath either side during auto-heal.

**Trade-off (documented in code + the hardening issue):** we lose forward secrecy on the rendezvous **signaling** keys *between* manual pairings — those now rotate only on an in-person re-pair, not on every auto-heal. Game traffic is unaffected (separately DTLS-protected) and topics still rotate daily. Re-enabling a *correct* ratchet needs a two-sided commit over the live channel so both ends advance together or neither does — deferred past the current "test what we have" phase.

## Testing
- `npm run p2p-reconnect` — all reconnect acceptance checks pass (multi-round heal, hang-up/call, restart, double-hang-up all exercise the changed `_settleEpisode` path).
- `npm run p2p-acceptance` — all checks pass, including the dead-drop rendezvous reconnect that proves the frozen-secret path re-establishes the same session and replays queued messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
